### PR TITLE
docs(rules): add docstring and comment documentation guidelines

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -45,6 +45,15 @@ paths:
 - Use `model_dump(exclude_unset=True)` for PATCH operations
 - Use `@computed_field` on `@property` for derived values in API responses
 
+## Docstrings
+
+- Use Google-style docstrings (compatible with `parse_docstring=True` and Sphinx)
+- One-line summary in imperative mood. Extended description only when the function does something non-obvious
+- `Args:` only when parameter names + types aren't self-explanatory. `Returns:` only when the return type annotation isn't sufficient. `Raises:` when callers need to handle domain exceptions
+- Pydantic models: do NOT add docstrings — field names, types, and `Field(description=...)` are the documentation. Only add a class-level docstring if the model's purpose isn't clear from its name
+- FastAPI endpoints: add a one-line docstring (it appears in the auto-generated OpenAPI/Swagger docs)
+- Test functions: do NOT add docstrings — the test name (`test_should_reject_expired_token`) is the documentation
+
 ## Python Async
 
 - Use `asyncio.TaskGroup` (not `asyncio.gather`) for concurrent operations — structured concurrency

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -32,6 +32,15 @@ description: Code quality and anti-pattern rules
 - Remove ALL commented-out code
 - The only acceptable logging is structured production logging
 
+## Documentation
+
+- Add docstrings to public functions, classes, and modules you create or substantially modify
+- Do NOT retroactively document code you didn't change
+- Prefer clear naming + type signatures over comments — only add comments when the "why" isn't obvious from the code
+- Do NOT document trivial/obvious functions (getters, one-liner utilities, Pydantic models where field names are self-documenting)
+- Do NOT add comments that restate the code (`# increment counter` above `counter += 1`)
+- When a framework reads docstrings at runtime (LangGraph `@tool`, FastAPI OpenAPI), always write them — they're functional, not decorative
+
 ## Dependencies
 
 - Do NOT add any package not listed in the SPEC or already in package.json/pyproject.toml without asking first

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -51,6 +51,14 @@ paths:
 - Use discriminated unions for mutually exclusive state, not boolean flags
 - Use `z.infer<typeof schema>` to derive types from Zod schemas — single source of truth
 
+## Documentation
+
+- Add `/** ... */` JSDoc to exported utility functions in `lib/` and custom hooks in `hooks/`
+- Do NOT add JSDoc to React components — the component name + props interface are the documentation
+- Do NOT add JSDoc to props interfaces — property names + TypeScript types are self-documenting
+- Server Actions and Route Handlers: add a one-line JSDoc describing what the action/handler does (these are effectively API endpoints)
+- Inline comments: explain "why" not "what" — non-obvious Tailwind workarounds, browser-specific hacks, Next.js caching behavior
+
 ## Tailwind + shadcn/ui
 
 - Never use inline styles — always Tailwind classes


### PR DESCRIPTION
## Summary

- Adds a `## Documentation` section to `code-quality.md` with cross-cutting philosophy: document public APIs you create, don't retroactively document code you didn't change, prefer self-documenting code
- Adds a `## Docstrings` section to `backend.md` with Python-specific format: Google-style, skip Pydantic models and test functions, one-liner on FastAPI endpoints for OpenAPI docs
- Adds a `## Documentation` section to `frontend.md` with TypeScript-specific guidance: JSDoc on exported hooks/utilities, skip components and props interfaces

## Why

CodeRabbit flags missing docstrings on public functions, but our rules had no guidance on when or how to write them — only rules for removing bad comments. This caused inconsistent documentation: sometimes over-documenting trivial code, sometimes missing docs on public APIs.

## What's NOT changing

- No ruff `D` (pydocstyle) rules added — enforcement stays at CodeRabbit PR-review level
- No new rule files — additions go into existing files following the current structure
- No changes to `CLAUDE.md`, `tdd.md`, `workflow.md`, `git.md`, or `infra.md`

## Test plan

- [x] `ruff check .` passes (no new lint rules added)
- [x] New rules align with typical CodeRabbit docstring flags (public functions/classes/modules, not trivial helpers or Pydantic models)
- [x] No conflicts with existing "Cleanup before commit" (complementary: cleanup removes junk, documentation defines what to add) or LangGraph tool docstring rules (new rules reinforce the existing `parse_docstring=True` requirement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated coding guidelines for docstrings and documentation standards across backend, frontend, and code quality rules. Changes include JSDoc conventions for frontend utilities, Google-style docstrings for backend code, and cleaner documentation practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->