### PR TITLE
fix: resolve inconsistent issue status rules and pick-task stale labels

### DIFF
--- a/.claude/agents/issue-tracker.md
+++ b/.claude/agents/issue-tracker.md
@@ -13,10 +13,12 @@ You are a GitHub Issues tracker for the calendar-agent project.
 - List all issues by status: `gh issue list --label "status:in-progress"` or `--label "status:todo"`
 - View issue details: `gh issue view <number> --json title,body,labels,state`
 - Update status: `gh issue edit <number> --add-label "status:done" --remove-label "status:in-progress"`
+- Fix stale labels on closed issues: `gh issue list --state closed --label "status:in-progress" --json number,title`
 - Summarize sprint progress: count done vs todo vs in-progress
 
 ## Rules
 
-- Never close issues — only update labels
+- Do not manually close issues — issues close automatically when their PR is merged
+- If a closed issue has a stale label (`status:in-progress` or `status:todo`), update it to `status:done`
 - Always report: total stories, completed, in-progress, todo, blocked
 - Flag any issues that have been `status:in-progress` without a linked PR

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -17,7 +17,11 @@ Follow this exact process for every story/task:
 7. **Refactor** while tests stay green
 8. **Verify**: run the full verification suite for your area
 9. **Commit**: conventional commit referencing the issue number
-10. **Update issue**: `gh issue edit <n> --add-label "status:done" --remove-label "status:in-progress"`
+10. **Update issue and open PR**:
+    ```bash
+    gh issue edit <n> --add-label "status:done" --remove-label "status:in-progress"
+    ```
+    Then create a PR referencing the issue (`Closes #<n>` in the PR body). The issue closes automatically when the PR is merged.
 
 ## When to ask the human
 

--- a/.claude/skills/pick-task/SKILL.md
+++ b/.claude/skills/pick-task/SKILL.md
@@ -15,10 +15,16 @@ Find the highest-priority unblocked story to work on next.
 
 2. **Get available stories** (excluding blocked):
    ```bash
-   gh issue list --label "type:story" --label "status:todo" --json number,title,body,labels --jq '[.[] | select(.labels | map(.name) | contains(["status:blocked"]) | not)] | .[] | "#\(.number) [\(.labels | map(.name) | join(", "))] \(.title)"'
+   gh issue list --state open --label "type:story" --label "status:todo" --json number,title,body,labels --jq '[.[] | select(.labels | map(.name) | contains(["status:blocked"]) | not)] | .[] | "#\(.number) [\(.labels | map(.name) | join(", "))] \(.title)"'
    ```
 
-3. **Check dependencies** — for each candidate, read the issue body and verify its dependencies are completed (issues referenced in "Dependencies" section should be `status:done`).
+3. **Check dependencies** — for each candidate, read the issue body and find dependency issue numbers from the "Dependencies" section. For each dependency:
+   ```bash
+   gh issue view <dep_number> --json state,labels --jq '{state: .state, done: ([.labels[].name] | contains(["status:done"]))}'
+   ```
+   A dependency is satisfied if EITHER:
+   - The issue has the `status:done` label, OR
+   - The issue state is `CLOSED` (treated as done even if the label wasn't updated)
 
 4. **Rank by**: priority:critical > priority:high > priority:medium, then sprint:day1 > sprint:day2.
 

--- a/.claude/skills/sync-issues/SKILL.md
+++ b/.claude/skills/sync-issues/SKILL.md
@@ -13,24 +13,33 @@ Review the current state of GitHub issues and sync them with reality.
 
 1. **Get current issue state**:
    ```bash
-   gh issue list --label "status:in-progress" --json number,title,labels
-   gh issue list --label "status:todo" --json number,title,labels
+   gh issue list --state open --label "status:in-progress" --json number,title,labels
+   gh issue list --state open --label "status:todo" --json number,title,labels
    ```
 
-2. **Check code state** — for each in-progress issue, verify if the work described in its acceptance criteria is actually done by checking the file scope listed in the issue.
+   Also check for **stale labels on closed issues** (closed but not labeled `status:done`):
+   ```bash
+   gh issue list --state closed --label "status:in-progress" --json number,title,labels
+   gh issue list --state closed --label "status:todo" --json number,title,labels
+   ```
+
+2. **Check code state** — for each open in-progress issue, verify if the work described in its acceptance criteria is actually done by checking the file scope listed in the issue.
 
 3. **Update statuses** (labels must be mutually exclusive — always remove old status):
    - If acceptance criteria are met → `gh issue edit <number> --add-label "status:done" --remove-label "status:in-progress" --remove-label "status:todo"`
    - If work hasn't started → keep at `status:todo` (no action needed)
    - If dependencies aren't met → `gh issue edit <number> --add-label "status:blocked" --remove-label "status:todo" --remove-label "status:in-progress"`
+   - If issue is **closed but has stale label** (`status:in-progress` or `status:todo`) → fix the label: `gh issue edit <number> --add-label "status:done" --remove-label "status:in-progress" --remove-label "status:todo"`
 
 4. **Report summary**:
    - Total: X stories
    - Done: X | In Progress: X | Todo: X | Blocked: X
+   - Stale labels fixed: X (closed issues whose labels were updated to `status:done`)
    - Next recommended stories to pick up (unblocked, highest priority)
 
 ## Rules
 
 - If an area filter is provided (e.g., "auth"), only check issues with that area label
-- Never close issues — only update status labels
+- Do not manually close issues — issues close automatically when their PR is merged
+- Fix stale labels: if a closed issue still has `status:in-progress` or `status:todo`, update its label to `status:done`
 - Flag any issues where the described file scope doesn't match what actually exists

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ IMPORTANT: Follow these rules strictly:
 - ALWAYS run tests after making changes
 - ALWAYS run lint and typecheck before considering work done
 - Before writing code, read the active spec in `.claude/specs/in-progress/`
-- Track work via GitHub Issues — pick stories labeled `status:todo`, mark `status:in-progress`, close when done
+- Track work via GitHub Issues — pick stories labeled `status:todo`, mark `status:in-progress`; when done update label to `status:done` and create a PR (the issue closes automatically when the PR merges)
 - Commit after each completed task with conventional commits referencing the issue number
 - If uncertain about approach, ASK before proceeding
 - When starting a session, check project state: `git log --oneline -10 && gh issue list --label "status:todo" --label "status:in-progress"`

--- a/docs/HUMAN-WORKFLOW.md
+++ b/docs/HUMAN-WORKFLOW.md
@@ -45,7 +45,7 @@ Then give each agent its task:
 Read the spec at .claude/specs/in-progress/SPEC.md, then work on issue #8.
 Run `gh issue view 8` to read the full acceptance criteria.
 Mark the issue in-progress: `gh issue edit 8 --add-label "status:in-progress" --remove-label "status:todo"`
-When done, commit and update the issue status.
+When done, commit, update the issue label to `status:done`, and create a PR.
 ```
 
 ### Option B: tmux (monitor all at once)
@@ -160,6 +160,7 @@ cd backend && uv run pytest
 
 # 5. Update the GitHub issue
 gh issue edit 8 --add-label "status:done" --remove-label "status:in-progress"
+# Issue closes automatically when the PR is merged
 
 # 6. Clean up the worktree
 git worktree remove .claude/worktrees/frontend-work
@@ -223,7 +224,7 @@ git push origin main
 
 # 5. Update issues
 gh issue list -R raulstechtips/calendar-agent --label "status:in-progress"
-# Close completed ones, add comments to in-progress ones
+# Verify completed ones have `status:done` label — issues close automatically when PRs merge
 
 # 6. Document progress (optional but recommended between days)
 # Have Claude write a progress summary:
@@ -261,7 +262,7 @@ Starting Day 2:
 | Merge worktree | `git checkout main && git merge worktree-<name>` |
 | Clean up worktree | `git worktree remove .claude/worktrees/<name>` |
 | Check issue status | `gh issue list --label "status:in-progress"` |
-| Update issue | `gh issue edit <n> --add-label "status:done" --remove-label "status:in-progress"` |
+| Update issue (done) | `gh issue edit <n> --add-label "status:done" --remove-label "status:in-progress"` (issue auto-closes on PR merge) |
 | Compact context | `/compact focus on [current task]` |
 | Clear and restart | `/clear` |
 | Resume last session | `claude --continue` |


### PR DESCRIPTION
## Summary

- **Fixed contradictory instructions** across 6 files about how to handle issue status when work is done. CLAUDE.md said "close when done" while skills/agents said "never close issues", causing agents to skip label updates entirely.
- **Fixed pick-task dependency check** to treat closed issues as done regardless of label — previously it failed when dependencies were closed (via PR merge) but still had `status:in-progress`.
- **Added stale label detection to sync-issues** — now queries closed issues with `status:in-progress` or `status:todo` labels and repairs them to `status:done`.

### Unified rule across all files:
> Update label to `status:done` → create PR with `Closes #N` → issue auto-closes when PR merges. Agents never manually close issues.

## Files changed
| File | Change |
|------|--------|
| `CLAUDE.md` | "close when done" → explicit label update + PR flow |
| `.claude/rules/workflow.md` | Step 10: label update + create PR instruction |
| `.claude/skills/pick-task/SKILL.md` | `--state open` filter + resilient dependency check |
| `.claude/skills/sync-issues/SKILL.md` | Stale label detection/repair for closed issues |
| `.claude/agents/issue-tracker.md` | Updated rules + stale label capability |
| `docs/HUMAN-WORKFLOW.md` | 4 locations updated for consistency |

## Test plan
- [ ] Run `/pick-task` — verify it only shows open `status:todo` issues
- [ ] Run `/sync-issues` — verify it detects and fixes closed issues with stale labels
- [ ] Verify `gh issue list --state closed --label "status:in-progress"` returns empty after sync
- [ ] Complete a story end-to-end and verify label updates to `status:done` before PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)