### PR TITLE
chore(ui): configure UI skills for Phase 3 stories

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -68,6 +68,16 @@ paths:
 - Mobile-first: unprefixed utilities are the mobile styles, use `md:`, `lg:` for larger screens
 - Never use arbitrary values (`mt-[13px]`) — use theme values
 - Extract repeated patterns into React components, not `@apply` classes
+- ALWAYS use the `shadcn` skill when adding new UI primitives — never copy-paste or manually create shadcn components
+
+## Available Skills
+
+Use these skills when working on frontend UI stories. Invoke via the Skill tool for best results.
+
+- **`shadcn`** — Adding, composing, or debugging shadcn/ui components. Use instead of manually creating component files
+- **`ui-ux-pro-max`** — Planning page layouts, choosing color palettes, reviewing UI/UX quality. Invoke for design decisions before building
+- **`vercel-react-best-practices`** — Optimizing React/Next.js performance: bundle size, data fetching, rendering strategies, code splitting
+- **`vercel-composition-patterns`** — Designing component architecture: compound components, render props, context providers. Includes React 19 patterns
 
 ## Component Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,15 @@ IMPORTANT: Follow these rules strictly:
 - `/sync-issues [area]` — Check issue status against actual code state
 - `/update-decision` — Record an architecture/product decision into SPEC.md and update affected issues
 
+### Contextual Skills (Frontend)
+
+Auto-available when working on `frontend/**`. See `.claude/rules/frontend.md` for usage guidance.
+
+- `shadcn` — shadcn/ui component management
+- `ui-ux-pro-max` — UI/UX design intelligence
+- `vercel-react-best-practices` — React/Next.js performance patterns
+- `vercel-composition-patterns` — React component architecture
+
 ## Decision Workflow
 
 When a decision is made (by the user or during implementation):


### PR DESCRIPTION
## Summary
- Added `## Available Skills` section to `.claude/rules/frontend.md` documenting when to use `shadcn`, `ui-ux-pro-max`, `vercel-react-best-practices`, and `vercel-composition-patterns`
- Added `shadcn` skill reference to the existing Tailwind + shadcn/ui section
- Added `### Contextual Skills (Frontend)` index to `CLAUDE.md` pointing to frontend.md for details

## Test plan
- [ ] Verify skills appear in system-reminder skill list when starting a conversation in this worktree
- [ ] Test `shadcn` skill invocation (e.g., `/shadcn add card`) to confirm it works with the existing `components.json`
- [ ] Confirm agents working on #23, #24, #25 pick up the skill guidance

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated frontend development guidelines with enhanced best practices for UI component implementation and expanded available development resources for the team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->