### PR TITLE
fix(agent): require security constraint review during planning step

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -11,7 +11,7 @@ Follow this exact process for every story/task:
 1. **Read the issue**: `gh issue view <number>` — understand acceptance criteria before writing code
 2. **Read the spec**: `.claude/specs/in-progress/SPEC.md` — understand architecture context
 3. **Explore existing code**: search for existing patterns to follow before writing anything new
-4. **Plan briefly**: list files to create/modify and patterns to follow
+4. **Plan thoroughly**: list files to create/modify, patterns to follow, and review the SPEC's Security Constraints section — for each constraint that applies to this story, note how the implementation will satisfy it
 5. **Write failing tests first** (Red phase) — see tdd.md
 6. **Implement minimum code to pass tests** (Green phase)
 7. **Refactor** while tests stay green


### PR DESCRIPTION
## Summary
- Changes workflow step 4 from "Plan briefly" to "Plan thoroughly" with an explicit directive to review SPEC Security Constraints (SC-1 through SC-10) and note how each applicable constraint will be satisfied
- Agents implementing auth stories (#10, #13) missed critical security gaps because nothing in the workflow forced them to cross-reference SPEC constraints during planning — issues were only caught post-hoc by code-reviewer

## Test plan
- [ ] Verify workflow.md step 4 now reads "Plan thoroughly" with security constraint cross-referencing
- [ ] Confirm no other files were modified
- [ ] On next agent story, observe that the agent's plan output includes SC-N references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated planning workflow guidance to emphasize thorough planning and include security constraint review procedures in the implementation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->