### PR TITLE
fix(infra): resolve Docker OAuth login and API routing issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,11 +35,15 @@ services:
     build:
       context: ./frontend
       args:
-        - NEXT_PUBLIC_API_URL=http://backend:8000
+        - NEXT_PUBLIC_API_URL=http://localhost:8000
     ports:
       - "3000:3000"
     env_file:
       - ./frontend/.env
+    environment:
+      NODE_ENV: development
+      AUTH_URL: http://localhost:3000
+      INTERNAL_API_URL: http://backend:8000
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,5 +4,8 @@ AUTH_GOOGLE_ID=
 AUTH_GOOGLE_SECRET=
 AUTH_TRUST_HOST=true
 
-# Backend URL (internal in production)
+# Backend URL — browser-facing (baked into client bundle at build time)
 NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Backend URL — server-side only (Docker internal DNS, overrides NEXT_PUBLIC_API_URL)
+# INTERNAL_API_URL=http://backend:8000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,7 +19,6 @@ RUN pnpm build
 # Stage 3: Production runner
 FROM node:24-alpine AS runner
 WORKDIR /app
-ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME=0.0.0.0
 ENV PORT=3000

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,7 +5,7 @@
 import { auth } from "../../auth";
 
 function getApiBaseUrl(): string {
-  return process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+  return process.env.INTERNAL_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 }
 
 export class ApiError extends Error {

--- a/frontend/src/lib/token-sync.ts
+++ b/frontend/src/lib/token-sync.ts
@@ -5,7 +5,7 @@
 import type { JWT } from "next-auth/jwt";
 
 const BACKEND_URL =
-  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+  process.env.INTERNAL_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 export async function syncTokenToBackend(token: JWT): Promise<void> {
   const { idToken, accessToken, refreshToken, expiresAt, scope } = token;


### PR DESCRIPTION
## Summary
- **OAuth redirect URI mismatch**: Added `AUTH_URL=http://localhost:3000` so Auth.js constructs correct callback URLs instead of deriving from `HOSTNAME=0.0.0.0`
- **PKCE cookie failure**: Removed hardcoded `NODE_ENV=production` from Dockerfile, set `NODE_ENV=development` in docker-compose so Auth.js doesn't force `Secure` cookies over plain HTTP
- **Server vs client API URL split**: Introduced `INTERNAL_API_URL` for server-side Docker DNS (`backend:8000`), kept `NEXT_PUBLIC_API_URL` for browser-facing calls (`localhost:8000`)

## Test plan
- [ ] `docker-compose up -d --build` starts all services
- [ ] Google OAuth login completes without redirect URI mismatch or PKCE errors
- [ ] Server-side API calls (token sync, user profile) reach backend via Docker DNS
- [ ] Client-side chat streaming reaches backend via localhost port mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API configuration to support both client-facing and internal server-side URLs across different environments (local development and production).
  * Enhanced environment variable setup for improved deployment flexibility and clearer separation between browser-accessible and internal backend endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->