### PR TITLE
feat(api): background context ingestion pipeline with delta sync

### DIFF
--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -1,10 +1,11 @@
 """Auth router — token sync, refresh, and revocation endpoints."""
 
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, BackgroundTasks, Depends, Response
 
 from app.auth.dependencies import get_current_user
 from app.auth.schemas import TokenRefreshResponse, TokenSyncRequest
 from app.auth.service import refresh_user_token, revoke_user_token, sync_token
+from app.context_ingestion.tasks import run_ingestion
 from app.users.schemas import UserResponse
 
 router = APIRouter()
@@ -13,10 +14,12 @@ router = APIRouter()
 @router.post("/api/auth/callback", status_code=204)
 async def auth_callback(
     body: TokenSyncRequest,
+    background_tasks: BackgroundTasks,
     user: UserResponse = Depends(get_current_user),  # noqa: B008
 ) -> Response:
-    """Store OAuth tokens in Redis after frontend sign-in or refresh."""
+    """Store OAuth tokens in Redis and trigger background context ingestion."""
     await sync_token(user.id, body)
+    background_tasks.add_task(run_ingestion, user.id)
     return Response(status_code=204)
 
 

--- a/backend/app/context_ingestion/sync.py
+++ b/backend/app/context_ingestion/sync.py
@@ -1,0 +1,232 @@
+"""Google Calendar sync engine with syncToken-based delta sync.
+
+Manages full ingestion (6 months back, 3 months forward) and incremental
+delta sync using Google Calendar's syncToken API. Sync metadata (syncToken,
+last_ingested_at) is stored in Redis.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from googleapiclient.errors import HttpError
+from pydantic import BaseModel
+
+from app.context_ingestion.service import ingest_events
+from app.core.redis import get_redis
+
+logger = logging.getLogger(__name__)
+
+_PAST_WINDOW_DAYS = 183  # ~6 months
+_FUTURE_WINDOW_DAYS = 91  # ~3 months
+
+
+class SyncMetadata(BaseModel):
+    sync_token: str = ""
+    last_ingested_at: int = 0
+
+
+class SyncTokenInvalidError(Exception):
+    """Raised when Google returns 410 Gone for an invalidated syncToken."""
+
+
+# ---------------------------------------------------------------------------
+# Redis metadata helpers
+# ---------------------------------------------------------------------------
+
+
+def _sync_metadata_key(user_id: str) -> str:
+    return f"sync_metadata:{user_id}:calendar"
+
+
+async def get_sync_metadata(user_id: str) -> SyncMetadata | None:
+    """Retrieve sync metadata from Redis. Returns None if no metadata exists."""
+    redis = get_redis()
+    data: dict[str, str] = await redis.hgetall(_sync_metadata_key(user_id))  # type: ignore[misc]
+    if not data:
+        return None
+    return SyncMetadata(
+        sync_token=data.get("sync_token", ""),
+        last_ingested_at=int(data.get("last_ingested_at", "0")),
+    )
+
+
+async def store_sync_metadata(user_id: str, metadata: SyncMetadata) -> None:
+    """Persist sync metadata to Redis (no TTL — lives as long as user has tokens)."""
+    redis = get_redis()
+    await redis.hset(  # type: ignore[misc]
+        name=_sync_metadata_key(user_id),
+        mapping={
+            "sync_token": metadata.sync_token,
+            "last_ingested_at": metadata.last_ingested_at,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Google Calendar service builder
+# ---------------------------------------------------------------------------
+
+
+async def _get_calendar_service(user_id: str) -> Any:
+    """Build a Google Calendar API service for the given user.
+
+    Reuses credential handling from calendar_tools to avoid duplicating
+    token refresh logic. Raises RuntimeError on failure.
+    """
+    from app.agents.tools.calendar_tools import (
+        _build_service,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    service = await _build_service(user_id)
+    if isinstance(service, str):
+        raise RuntimeError(service)
+    return service
+
+
+# ---------------------------------------------------------------------------
+# Paginated event fetcher
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_all_events(
+    service: Any,
+    *,
+    time_min: str | None = None,
+    time_max: str | None = None,
+    sync_token: str | None = None,
+) -> tuple[list[dict[str, Any]], str]:
+    """Fetch all events from Google Calendar, handling pagination.
+
+    Pass time_min/time_max for full ingest, or sync_token for delta sync.
+    Returns (events, nextSyncToken).
+
+    Raises:
+        SyncTokenInvalidError: If Google returns 410 Gone (stale syncToken).
+    """
+    loop = asyncio.get_running_loop()
+    all_events: list[dict[str, Any]] = []
+    page_token: str | None = None
+    next_sync_token: str = ""
+
+    while True:
+        kwargs: dict[str, Any] = {"calendarId": "primary"}
+
+        if sync_token:
+            kwargs["syncToken"] = sync_token
+        else:
+            if time_min:
+                kwargs["timeMin"] = time_min
+            if time_max:
+                kwargs["timeMax"] = time_max
+            kwargs["singleEvents"] = True
+
+        if page_token:
+            kwargs["pageToken"] = page_token
+
+        def _execute_list(
+            svc: Any = service, kw: dict[str, Any] = kwargs
+        ) -> dict[str, Any]:
+            return svc.events().list(**kw).execute()  # type: ignore[no-any-return]
+
+        try:
+            result: dict[str, Any] = await loop.run_in_executor(None, _execute_list)
+        except HttpError as e:
+            if e.resp.status == 410:
+                raise SyncTokenInvalidError(
+                    "syncToken invalidated by Google (410 Gone)"
+                ) from e
+            raise
+
+        all_events.extend(result.get("items", []))
+
+        page_token = result.get("nextPageToken")
+        if not page_token:
+            next_sync_token = result.get("nextSyncToken", "")
+            break
+
+    return all_events, next_sync_token
+
+
+# ---------------------------------------------------------------------------
+# Core sync functions
+# ---------------------------------------------------------------------------
+
+
+async def full_ingest(user_id: str) -> None:
+    """Perform a full calendar event ingest (6 months back, 3 months forward).
+
+    Fetches all events in the time window, embeds them, upserts to the search
+    index, and stores the sync metadata in Redis.
+    """
+    service = await _get_calendar_service(user_id)
+
+    now = datetime.now(UTC)
+    time_min = (now - timedelta(days=_PAST_WINDOW_DAYS)).isoformat()
+    time_max = (now + timedelta(days=_FUTURE_WINDOW_DAYS)).isoformat()
+
+    events, sync_token = await _fetch_all_events(
+        service, time_min=time_min, time_max=time_max
+    )
+
+    await ingest_events(user_id=user_id, created=events)
+
+    await store_sync_metadata(
+        user_id,
+        SyncMetadata(sync_token=sync_token, last_ingested_at=int(time.time())),
+    )
+
+    logger.info(
+        "Full ingest complete for user %s: %d events ingested",
+        user_id,
+        len(events),
+    )
+
+
+async def delta_sync(user_id: str, metadata: SyncMetadata) -> None:
+    """Perform an incremental sync using the stored Google Calendar syncToken.
+
+    Classifies returned events as updated or deleted and routes them
+    to the ingestion service. Falls back to full_ingest if the syncToken
+    is invalidated by Google (410 Gone).
+    """
+    service = await _get_calendar_service(user_id)
+
+    try:
+        events, new_sync_token = await _fetch_all_events(
+            service, sync_token=metadata.sync_token
+        )
+    except SyncTokenInvalidError:
+        logger.warning(
+            "syncToken invalidated for user %s — falling back to full ingest",
+            user_id,
+        )
+        await full_ingest(user_id)
+        return
+
+    updated: list[dict[str, Any]] = []
+    deleted_ids: list[str] = []
+
+    for event in events:
+        if event.get("status") == "cancelled":
+            deleted_ids.append(event["id"])
+        else:
+            updated.append(event)
+
+    await ingest_events(user_id=user_id, updated=updated, deleted_ids=deleted_ids)
+
+    await store_sync_metadata(
+        user_id,
+        SyncMetadata(sync_token=new_sync_token, last_ingested_at=int(time.time())),
+    )
+
+    logger.info(
+        "Delta sync complete for user %s: %d updated, %d deleted",
+        user_id,
+        len(updated),
+        len(deleted_ids),
+    )

--- a/backend/app/context_ingestion/tasks.py
+++ b/backend/app/context_ingestion/tasks.py
@@ -1,0 +1,52 @@
+"""Background task wrappers for context ingestion.
+
+Entry point for FastAPI BackgroundTasks — decides between full ingest
+and delta sync, respects cooldown, and suppresses all errors so the
+login flow is never blocked.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from app.context_ingestion.sync import (
+    delta_sync,
+    full_ingest,
+    get_sync_metadata,
+)
+
+logger = logging.getLogger(__name__)
+
+_COOLDOWN_SECONDS = 3600  # 1 hour
+
+
+async def run_ingestion(user_id: str) -> None:
+    """Decide between full ingest and delta sync, respecting cooldown.
+
+    Intended to be called as a FastAPI BackgroundTask. All errors are caught
+    and logged — this function never raises.
+    """
+    try:
+        metadata = await get_sync_metadata(user_id)
+
+        if metadata is None or not metadata.sync_token:
+            logger.info("Starting full ingest for user %s", user_id)
+            await full_ingest(user_id)
+            return
+
+        now = int(time.time())
+        elapsed = now - metadata.last_ingested_at
+        if elapsed < _COOLDOWN_SECONDS:
+            logger.info(
+                "Skipping sync for user %s — cooldown active (last sync %ds ago)",
+                user_id,
+                elapsed,
+            )
+            return
+
+        logger.info("Starting delta sync for user %s", user_id)
+        await delta_sync(user_id, metadata)
+
+    except Exception:
+        logger.exception("Background ingestion failed for user %s", user_id)

--- a/backend/tests/test_auth_router.py
+++ b/backend/tests/test_auth_router.py
@@ -100,8 +100,10 @@ def _sample_stored_token() -> StoredToken:
 
 
 class TestAuthCallbackEndpoint:
+    @patch("app.auth.router.run_ingestion", new_callable=AsyncMock)
     async def test_should_return_204_on_valid_token_sync(
         self,
+        mock_ingestion: AsyncMock,
         client: httpx.AsyncClient,
         mock_user: UserResponse,
         valid_sync_body: dict[str, object],
@@ -143,8 +145,10 @@ class TestAuthCallbackEndpoint:
         )
         assert response.status_code == 422
 
+    @patch("app.auth.router.run_ingestion", new_callable=AsyncMock)
     async def test_should_return_500_on_encryption_failure(
         self,
+        mock_ingestion: AsyncMock,
         client: httpx.AsyncClient,
         mock_user: UserResponse,
         valid_sync_body: dict[str, object],
@@ -159,6 +163,21 @@ class TestAuthCallbackEndpoint:
             response = await client.post("/api/auth/callback", json=valid_sync_body)
 
         assert response.status_code == 500
+
+    @patch("app.auth.router.run_ingestion", new_callable=AsyncMock)
+    async def test_should_trigger_background_ingestion(
+        self,
+        mock_ingestion: AsyncMock,
+        client: httpx.AsyncClient,
+        mock_user: UserResponse,
+        valid_sync_body: dict[str, object],
+    ) -> None:
+        _override_user(mock_user)
+
+        with patch("app.auth.service.store_token", new_callable=AsyncMock):
+            await client.post("/api/auth/callback", json=valid_sync_body)
+
+        mock_ingestion.assert_awaited_once_with(TEST_USER_ID)
 
 
 class TestAuthRefreshEndpoint:

--- a/backend/tests/test_context_ingestion.py
+++ b/backend/tests/test_context_ingestion.py
@@ -1,11 +1,18 @@
-"""Tests for the context ingestion orchestrator."""
+"""Tests for the context ingestion orchestrator and sync pipeline."""
 
 from __future__ import annotations
 
+import time
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from app.context_ingestion.sync import (
+    SyncMetadata,
+    SyncTokenInvalidError,
+    _fetch_all_events,  # pyright: ignore[reportPrivateUsage]
+)
 
 
 def _make_event(
@@ -126,3 +133,477 @@ class TestIngestEvents:
 
         mock_process.assert_not_awaited()
         mock_delete.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# SyncMetadata Redis helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSyncMetadata:
+    async def test_should_return_none_when_no_metadata(self) -> None:
+        from app.context_ingestion.sync import get_sync_metadata
+
+        mock_redis = AsyncMock()
+        mock_redis.hgetall.return_value = {}
+
+        with patch("app.context_ingestion.sync.get_redis", return_value=mock_redis):
+            result = await get_sync_metadata("user-123")
+
+        assert result is None
+        mock_redis.hgetall.assert_awaited_once_with("sync_metadata:user-123:calendar")
+
+    async def test_should_return_metadata_when_exists(self) -> None:
+        from app.context_ingestion.sync import get_sync_metadata
+
+        mock_redis = AsyncMock()
+        mock_redis.hgetall.return_value = {
+            "sync_token": "some-sync-token",
+            "last_ingested_at": "1710000000",
+        }
+
+        with patch("app.context_ingestion.sync.get_redis", return_value=mock_redis):
+            result = await get_sync_metadata("user-123")
+
+        assert result is not None
+        assert result.sync_token == "some-sync-token"
+        assert result.last_ingested_at == 1710000000
+
+    async def test_should_store_metadata_in_redis(self) -> None:
+        from app.context_ingestion.sync import store_sync_metadata
+
+        mock_redis = AsyncMock()
+        metadata = SyncMetadata(sync_token="tok-abc", last_ingested_at=1710000000)
+
+        with patch("app.context_ingestion.sync.get_redis", return_value=mock_redis):
+            await store_sync_metadata("user-123", metadata)
+
+        mock_redis.hset.assert_awaited_once()
+        call_args = mock_redis.hset.call_args
+        assert call_args.kwargs["name"] == "sync_metadata:user-123:calendar"
+        mapping = call_args.kwargs["mapping"]
+        assert mapping["sync_token"] == "tok-abc"
+        assert mapping["last_ingested_at"] == 1710000000
+
+    async def test_should_treat_empty_sync_token_as_no_metadata(self) -> None:
+        from app.context_ingestion.sync import get_sync_metadata
+
+        mock_redis = AsyncMock()
+        mock_redis.hgetall.return_value = {
+            "sync_token": "",
+            "last_ingested_at": "1710000000",
+        }
+
+        with patch("app.context_ingestion.sync.get_redis", return_value=mock_redis):
+            result = await get_sync_metadata("user-123")
+
+        # Returns metadata but sync_token is empty — caller checks emptiness
+        assert result is not None
+        assert result.sync_token == ""
+
+
+# ---------------------------------------------------------------------------
+# _fetch_all_events — paginated Google Calendar fetcher
+# ---------------------------------------------------------------------------
+
+
+def _mock_events_list(
+    events: list[dict[str, Any]],
+    next_page_token: str | None = None,
+    next_sync_token: str | None = None,
+) -> dict[str, Any]:
+    response: dict[str, Any] = {"items": events}
+    if next_page_token:
+        response["nextPageToken"] = next_page_token
+    if next_sync_token:
+        response["nextSyncToken"] = next_sync_token
+    return response
+
+
+class TestFetchAllEvents:
+    async def test_should_fetch_single_page(self) -> None:
+
+        events = [_make_event(event_id="evt-1")]
+        mock_service = MagicMock()
+        mock_service.events.return_value.list.return_value.execute.return_value = (
+            _mock_events_list(events, next_sync_token="sync-tok-1")
+        )
+
+        result_events, sync_token = await _fetch_all_events(
+            mock_service,
+            time_min="2025-09-01T00:00:00Z",
+            time_max="2026-06-01T00:00:00Z",
+        )
+
+        assert len(result_events) == 1
+        assert result_events[0]["id"] == "evt-1"
+        assert sync_token == "sync-tok-1"
+
+    async def test_should_paginate_multiple_pages(self) -> None:
+
+        page1 = _mock_events_list(
+            [_make_event(event_id="evt-1")],
+            next_page_token="page-2-token",
+        )
+        page2 = _mock_events_list(
+            [_make_event(event_id="evt-2")],
+            next_sync_token="sync-tok-final",
+        )
+
+        mock_service = MagicMock()
+        mock_service.events.return_value.list.return_value.execute.side_effect = [
+            page1,
+            page2,
+        ]
+
+        result_events, sync_token = await _fetch_all_events(
+            mock_service,
+            time_min="2025-09-01T00:00:00Z",
+            time_max="2026-06-01T00:00:00Z",
+        )
+
+        assert len(result_events) == 2
+        assert result_events[0]["id"] == "evt-1"
+        assert result_events[1]["id"] == "evt-2"
+        assert sync_token == "sync-tok-final"
+
+    async def test_should_raise_sync_token_invalid_on_410(self) -> None:
+        from googleapiclient.errors import HttpError
+
+        mock_resp = MagicMock()
+        mock_resp.status = 410
+        mock_resp.reason = "Gone"
+        http_error = HttpError(mock_resp, b"Resource has been deleted")
+
+        mock_service = MagicMock()
+        mock_service.events.return_value.list.return_value.execute.side_effect = (
+            http_error
+        )
+
+        with pytest.raises(SyncTokenInvalidError):
+            await _fetch_all_events(mock_service, sync_token="stale-token")
+
+    async def test_should_pass_sync_token_without_time_filters(self) -> None:
+
+        mock_service = MagicMock()
+        mock_service.events.return_value.list.return_value.execute.return_value = (
+            _mock_events_list([], next_sync_token="new-token")
+        )
+
+        await _fetch_all_events(mock_service, sync_token="old-token")
+
+        list_call = mock_service.events.return_value.list
+        call_kwargs = list_call.call_args.kwargs
+        assert call_kwargs.get("syncToken") == "old-token"
+        assert "timeMin" not in call_kwargs
+        assert "timeMax" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# full_ingest
+# ---------------------------------------------------------------------------
+
+
+class TestFullIngest:
+    @patch("app.context_ingestion.sync.store_sync_metadata", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync.ingest_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._fetch_all_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._get_calendar_service", new_callable=AsyncMock)
+    async def test_should_call_ingest_events_with_fetched_events(
+        self,
+        mock_service: AsyncMock,
+        mock_fetch: AsyncMock,
+        mock_ingest: AsyncMock,
+        mock_store_meta: AsyncMock,
+    ) -> None:
+        from app.context_ingestion.sync import full_ingest
+
+        events = [_make_event(event_id="evt-1"), _make_event(event_id="evt-2")]
+        mock_fetch.return_value = (events, "sync-tok-1")
+
+        await full_ingest("user-123")
+
+        mock_ingest.assert_awaited_once()
+        call_kwargs = mock_ingest.call_args.kwargs
+        assert call_kwargs["user_id"] == "user-123"
+        assert len(call_kwargs["created"]) == 2
+
+    @patch("app.context_ingestion.sync.store_sync_metadata", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync.ingest_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._fetch_all_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._get_calendar_service", new_callable=AsyncMock)
+    async def test_should_store_sync_metadata_after_success(
+        self,
+        mock_service: AsyncMock,
+        mock_fetch: AsyncMock,
+        mock_ingest: AsyncMock,
+        mock_store_meta: AsyncMock,
+    ) -> None:
+        from app.context_ingestion.sync import full_ingest
+
+        mock_fetch.return_value = ([], "sync-tok-new")
+
+        await full_ingest("user-123")
+
+        mock_store_meta.assert_awaited_once()
+        call_args = mock_store_meta.call_args
+        assert call_args[0][0] == "user-123"
+        metadata: SyncMetadata = call_args[0][1]
+        assert metadata.sync_token == "sync-tok-new"
+        assert metadata.last_ingested_at > 0
+
+    @patch("app.context_ingestion.sync.store_sync_metadata", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync.ingest_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._fetch_all_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._get_calendar_service", new_callable=AsyncMock)
+    async def test_should_fetch_with_time_window(
+        self,
+        mock_service: AsyncMock,
+        mock_fetch: AsyncMock,
+        mock_ingest: AsyncMock,
+        mock_store_meta: AsyncMock,
+    ) -> None:
+        from app.context_ingestion.sync import full_ingest
+
+        mock_fetch.return_value = ([], "tok")
+
+        await full_ingest("user-123")
+
+        mock_fetch.assert_awaited_once()
+        call_kwargs = mock_fetch.call_args.kwargs
+        assert "time_min" in call_kwargs
+        assert "time_max" in call_kwargs
+        # time_min should be roughly 6 months ago, time_max ~3 months ahead
+        assert call_kwargs["time_min"] < call_kwargs["time_max"]
+
+    @patch("app.context_ingestion.sync.store_sync_metadata", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync.ingest_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._fetch_all_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._get_calendar_service", new_callable=AsyncMock)
+    async def test_should_handle_empty_calendar(
+        self,
+        mock_service: AsyncMock,
+        mock_fetch: AsyncMock,
+        mock_ingest: AsyncMock,
+        mock_store_meta: AsyncMock,
+    ) -> None:
+        from app.context_ingestion.sync import full_ingest
+
+        mock_fetch.return_value = ([], "sync-tok-empty")
+
+        await full_ingest("user-123")
+
+        mock_ingest.assert_awaited_once()
+        assert mock_ingest.call_args.kwargs["created"] == []
+        mock_store_meta.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# delta_sync
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaSync:
+    @patch("app.context_ingestion.sync.store_sync_metadata", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync.ingest_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._fetch_all_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._get_calendar_service", new_callable=AsyncMock)
+    async def test_should_classify_cancelled_as_deletes(
+        self,
+        mock_service: AsyncMock,
+        mock_fetch: AsyncMock,
+        mock_ingest: AsyncMock,
+        mock_store_meta: AsyncMock,
+    ) -> None:
+        from app.context_ingestion.sync import delta_sync
+
+        cancelled = {"id": "evt-del", "status": "cancelled"}
+        mock_fetch.return_value = ([cancelled], "new-sync-tok")
+        metadata = SyncMetadata(sync_token="old-tok", last_ingested_at=1710000000)
+
+        await delta_sync("user-123", metadata)
+
+        mock_ingest.assert_awaited_once()
+        call_kwargs = mock_ingest.call_args.kwargs
+        assert call_kwargs["deleted_ids"] == ["evt-del"]
+        assert call_kwargs.get("updated") == []
+
+    @patch("app.context_ingestion.sync.store_sync_metadata", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync.ingest_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._fetch_all_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._get_calendar_service", new_callable=AsyncMock)
+    async def test_should_classify_active_as_updates(
+        self,
+        mock_service: AsyncMock,
+        mock_fetch: AsyncMock,
+        mock_ingest: AsyncMock,
+        mock_store_meta: AsyncMock,
+    ) -> None:
+        from app.context_ingestion.sync import delta_sync
+
+        active = _make_event(event_id="evt-upd")
+        mock_fetch.return_value = ([active], "new-sync-tok")
+        metadata = SyncMetadata(sync_token="old-tok", last_ingested_at=1710000000)
+
+        await delta_sync("user-123", metadata)
+
+        mock_ingest.assert_awaited_once()
+        call_kwargs = mock_ingest.call_args.kwargs
+        assert len(call_kwargs["updated"]) == 1
+        assert call_kwargs["updated"][0]["id"] == "evt-upd"
+        assert call_kwargs["deleted_ids"] == []
+
+    @patch("app.context_ingestion.sync.store_sync_metadata", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync.ingest_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._fetch_all_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._get_calendar_service", new_callable=AsyncMock)
+    async def test_should_handle_mixed_updates_and_deletes(
+        self,
+        mock_service: AsyncMock,
+        mock_fetch: AsyncMock,
+        mock_ingest: AsyncMock,
+        mock_store_meta: AsyncMock,
+    ) -> None:
+        from app.context_ingestion.sync import delta_sync
+
+        events = [
+            _make_event(event_id="evt-1"),
+            {"id": "evt-2", "status": "cancelled"},
+            _make_event(event_id="evt-3"),
+        ]
+        mock_fetch.return_value = (events, "new-tok")
+        metadata = SyncMetadata(sync_token="old-tok", last_ingested_at=1710000000)
+
+        await delta_sync("user-123", metadata)
+
+        call_kwargs = mock_ingest.call_args.kwargs
+        assert len(call_kwargs["updated"]) == 2
+        assert call_kwargs["deleted_ids"] == ["evt-2"]
+
+    @patch("app.context_ingestion.sync.full_ingest", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync.store_sync_metadata", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync.ingest_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._fetch_all_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._get_calendar_service", new_callable=AsyncMock)
+    async def test_should_fallback_to_full_ingest_on_sync_token_invalid(
+        self,
+        mock_service: AsyncMock,
+        mock_fetch: AsyncMock,
+        mock_ingest: AsyncMock,
+        mock_store_meta: AsyncMock,
+        mock_full_ingest: AsyncMock,
+    ) -> None:
+        from app.context_ingestion.sync import delta_sync
+
+        mock_fetch.side_effect = SyncTokenInvalidError("token expired")
+        metadata = SyncMetadata(sync_token="stale-tok", last_ingested_at=1710000000)
+
+        await delta_sync("user-123", metadata)
+
+        mock_full_ingest.assert_awaited_once_with("user-123")
+        mock_ingest.assert_not_awaited()
+
+    @patch("app.context_ingestion.sync.store_sync_metadata", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync.ingest_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._fetch_all_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._get_calendar_service", new_callable=AsyncMock)
+    async def test_should_store_new_sync_token(
+        self,
+        mock_service: AsyncMock,
+        mock_fetch: AsyncMock,
+        mock_ingest: AsyncMock,
+        mock_store_meta: AsyncMock,
+    ) -> None:
+        from app.context_ingestion.sync import delta_sync
+
+        mock_fetch.return_value = ([], "brand-new-tok")
+        metadata = SyncMetadata(sync_token="old-tok", last_ingested_at=1710000000)
+
+        await delta_sync("user-123", metadata)
+
+        mock_store_meta.assert_awaited_once()
+        stored: SyncMetadata = mock_store_meta.call_args[0][1]
+        assert stored.sync_token == "brand-new-tok"
+        assert stored.last_ingested_at > 0
+
+
+# ---------------------------------------------------------------------------
+# run_ingestion — BackgroundTask wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestRunIngestion:
+    @patch("app.context_ingestion.tasks.full_ingest", new_callable=AsyncMock)
+    @patch("app.context_ingestion.tasks.get_sync_metadata", new_callable=AsyncMock)
+    async def test_should_full_ingest_when_no_metadata(
+        self, mock_get_meta: AsyncMock, mock_full: AsyncMock
+    ) -> None:
+        from app.context_ingestion.tasks import run_ingestion
+
+        mock_get_meta.return_value = None
+
+        await run_ingestion("user-123")
+
+        mock_full.assert_awaited_once_with("user-123")
+
+    @patch("app.context_ingestion.tasks.full_ingest", new_callable=AsyncMock)
+    @patch("app.context_ingestion.tasks.get_sync_metadata", new_callable=AsyncMock)
+    async def test_should_full_ingest_when_no_sync_token(
+        self, mock_get_meta: AsyncMock, mock_full: AsyncMock
+    ) -> None:
+        from app.context_ingestion.tasks import run_ingestion
+
+        mock_get_meta.return_value = SyncMetadata(sync_token="", last_ingested_at=0)
+
+        await run_ingestion("user-123")
+
+        mock_full.assert_awaited_once_with("user-123")
+
+    @patch("app.context_ingestion.tasks.delta_sync", new_callable=AsyncMock)
+    @patch("app.context_ingestion.tasks.full_ingest", new_callable=AsyncMock)
+    @patch("app.context_ingestion.tasks.get_sync_metadata", new_callable=AsyncMock)
+    async def test_should_skip_when_within_cooldown(
+        self,
+        mock_get_meta: AsyncMock,
+        mock_full: AsyncMock,
+        mock_delta: AsyncMock,
+    ) -> None:
+        from app.context_ingestion.tasks import run_ingestion
+
+        mock_get_meta.return_value = SyncMetadata(
+            sync_token="valid-tok", last_ingested_at=int(time.time()) - 600
+        )
+
+        await run_ingestion("user-123")
+
+        mock_full.assert_not_awaited()
+        mock_delta.assert_not_awaited()
+
+    @patch("app.context_ingestion.tasks.delta_sync", new_callable=AsyncMock)
+    @patch("app.context_ingestion.tasks.get_sync_metadata", new_callable=AsyncMock)
+    async def test_should_delta_sync_after_cooldown(
+        self, mock_get_meta: AsyncMock, mock_delta: AsyncMock
+    ) -> None:
+        from app.context_ingestion.tasks import run_ingestion
+
+        metadata = SyncMetadata(
+            sync_token="valid-tok", last_ingested_at=int(time.time()) - 7200
+        )
+        mock_get_meta.return_value = metadata
+
+        await run_ingestion("user-123")
+
+        mock_delta.assert_awaited_once_with("user-123", metadata)
+
+    @patch("app.context_ingestion.tasks.full_ingest", new_callable=AsyncMock)
+    @patch("app.context_ingestion.tasks.get_sync_metadata", new_callable=AsyncMock)
+    async def test_should_not_raise_on_failure(
+        self, mock_get_meta: AsyncMock, mock_full: AsyncMock
+    ) -> None:
+        from app.context_ingestion.tasks import run_ingestion
+
+        mock_get_meta.return_value = None
+        mock_full.side_effect = RuntimeError("service unavailable")
+
+        # Should not raise — errors are logged and swallowed
+        await run_ingestion("user-123")


### PR DESCRIPTION
## Summary
- On auth callback, triggers a `BackgroundTask` that ingests calendar events into Azure AI Search for RAG
- First login: full ingest (6 months back, 3 months forward) using Google Calendar Events API with pagination
- Subsequent logins: delta sync via Google Calendar `syncToken` — only fetches created/updated/deleted events
- 1-hour cooldown prevents redundant syncs on frequent logins
- `syncToken` and `last_ingested_at` stored in Redis hash (`sync_metadata:{user_id}:calendar`)
- Falls back to full re-ingest if Google invalidates the syncToken (410 Gone)
- All errors logged but never block the login flow

## Files changed
- **NEW** `backend/app/context_ingestion/sync.py` — Sync engine: `SyncMetadata`, Redis helpers, paginated fetch, `full_ingest()`, `delta_sync()`
- **NEW** `backend/app/context_ingestion/tasks.py` — `run_ingestion()` BackgroundTask entry point with cooldown and error suppression
- **MODIFIED** `backend/app/auth/router.py` — Added `BackgroundTasks` to auth callback, triggers `run_ingestion`
- **MODIFIED** `backend/tests/test_context_ingestion.py` — 22 new tests (SyncMetadata, fetch, full ingest, delta sync, run_ingestion)
- **MODIFIED** `backend/tests/test_auth_router.py` — Patched existing callback tests, added ingestion trigger test

## Test plan
- [x] `pytest tests/test_context_ingestion.py` — 29 tests pass (7 existing + 22 new)
- [x] `pytest tests/test_auth_router.py` — 19 tests pass (18 existing + 1 new)
- [x] Full test suite: 284/289 pass (5 pre-existing failures in test_guardrails.py)
- [x] `ruff check .` — no lint errors
- [x] `ruff format --check .` — all files formatted
- [x] `mypy .` — no type errors
- [x] `pyright` — no new errors (1 pre-existing in calendar_agent.py)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic background synchronization of Google Calendar events now triggers after sign-in or token refresh, keeping your calendar data current without manual intervention. The system intelligently syncs only recent changes when possible and includes built-in cooldown protection for optimal performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->