### PR TITLE
fix(search): add batching and exponential backoff to embedding pipeline

### DIFF
--- a/backend/app/agents/tools/search_tools.py
+++ b/backend/app/agents/tools/search_tools.py
@@ -30,9 +30,7 @@ def _parse_datetime(value: str | None) -> datetime | None:
         return None
 
 
-def _compute_recency_factor(
-    timestamp: str | None, last_modified: str | None
-) -> float:
+def _compute_recency_factor(timestamp: str | None, last_modified: str | None) -> float:
     """Compute a recency factor between 0 and 1 using hyperbolic decay.
 
     Uses the more recent of timestamp and last_modified so that

--- a/backend/app/context_ingestion/sync.py
+++ b/backend/app/context_ingestion/sync.py
@@ -173,12 +173,13 @@ async def full_ingest(user_id: str) -> None:
         service, time_min=time_min, time_max=time_max
     )
 
-    await ingest_events(user_id=user_id, created=events)
-
+    # Store metadata first so partial failures don't cause full re-ingest loops
     await store_sync_metadata(
         user_id,
         SyncMetadata(sync_token=sync_token, last_ingested_at=int(time.time())),
     )
+
+    await ingest_events(user_id=user_id, created=events)
 
     logger.info(
         "Full ingest complete for user %s: %d events ingested",
@@ -217,12 +218,13 @@ async def delta_sync(user_id: str, metadata: SyncMetadata) -> None:
         else:
             updated.append(event)
 
-    await ingest_events(user_id=user_id, updated=updated, deleted_ids=deleted_ids)
-
+    # Store metadata first so partial failures don't cause full re-ingest loops
     await store_sync_metadata(
         user_id,
         SyncMetadata(sync_token=new_sync_token, last_ingested_at=int(time.time())),
     )
+
+    await ingest_events(user_id=user_id, updated=updated, deleted_ids=deleted_ids)
 
     logger.info(
         "Delta sync complete for user %s: %d updated, %d deleted",

--- a/backend/app/context_ingestion/tasks.py
+++ b/backend/app/context_ingestion/tasks.py
@@ -7,6 +7,7 @@ login flow is never blocked.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 
@@ -33,6 +34,7 @@ async def run_ingestion(user_id: str) -> None:
         if metadata is None or not metadata.sync_token:
             logger.info("Starting full ingest for user %s", user_id)
             await full_ingest(user_id)
+            logger.info("Ingestion complete for user %s", user_id)
             return
 
         now = int(time.time())
@@ -47,6 +49,10 @@ async def run_ingestion(user_id: str) -> None:
 
         logger.info("Starting delta sync for user %s", user_id)
         await delta_sync(user_id, metadata)
+        logger.info("Ingestion complete for user %s", user_id)
 
+    except asyncio.CancelledError:
+        logger.info("Ingestion task cancelled for user %s", user_id)
+        raise
     except Exception:
         logger.exception("Background ingestion failed for user %s", user_id)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -21,6 +21,13 @@ class Settings(BaseSettings):
     # Azure AI Content Safety — no API key; uses DefaultAzureCredential
     azure_content_safety_endpoint: str = ""
 
+    # Embedding pipeline
+    embedding_batch_size: int = 50
+    embedding_max_retries: int = 3
+    embedding_retry_initial_delay: float = 1.0
+    embedding_batch_delay: float = 1.0
+    embedding_max_text_length: int = 5000
+
     # Redis
     redis_url: str = "redis://localhost:6379/0"
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,6 +1,6 @@
 """Application settings loaded from environment variables."""
 
-from pydantic import field_validator
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -22,11 +22,11 @@ class Settings(BaseSettings):
     azure_content_safety_endpoint: str = ""
 
     # Embedding pipeline
-    embedding_batch_size: int = 50
-    embedding_max_retries: int = 3
-    embedding_retry_initial_delay: float = 1.0
-    embedding_batch_delay: float = 1.0
-    embedding_max_text_length: int = 5000
+    embedding_batch_size: int = Field(default=50, gt=0)
+    embedding_max_retries: int = Field(default=3, ge=1)
+    embedding_retry_initial_delay: float = Field(default=1.0, gt=0)
+    embedding_batch_delay: float = Field(default=1.0, ge=0)
+    embedding_max_text_length: int = Field(default=5000, gt=0)
 
     # Redis
     redis_url: str = "redis://localhost:6379/0"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.search.index import create_index
 from app.search.service import close_search_client, get_search_client
 from app.users.router import router as users_router
 
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from app.auth.router import router as auth_router
 from app.core.middleware import setup_middleware
 from app.core.redis import close_redis, get_redis
 from app.search.embeddings import close_embeddings_client, get_embeddings_client
+from app.search.index import create_index
 from app.search.service import close_search_client, get_search_client
 from app.users.router import router as users_router
 
@@ -23,6 +24,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     get_redis()
     get_search_client()
     get_embeddings_client()
+    # Ensure search index exists (idempotent — safe on every startup)
+    await create_index()
+    logger.info("Search index ready")
     yield
     # Shutdown: clean up connections (isolate exceptions so both always run)
     try:

--- a/backend/app/search/embeddings.py
+++ b/backend/app/search/embeddings.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import UTC, datetime
 from typing import Any
 
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from langchain_openai import AzureOpenAIEmbeddings
+from openai import (
+    APIConnectionError,
+    APITimeoutError,
+    InternalServerError,
+    RateLimitError,
+)
 
 from app.core.config import settings
 from app.search.service import delete_documents, upsert_documents
@@ -97,7 +104,11 @@ def format_event_text(event: dict[str, Any]) -> str:
     if description:
         lines.append(f"Description: {description}")
 
-    return "\n".join(lines)
+    text = "\n".join(lines)
+    max_len = settings.embedding_max_text_length
+    if len(text) > max_len:
+        text = text[:max_len]
+    return text
 
 
 def build_search_document(
@@ -119,8 +130,67 @@ def build_search_document(
     }
 
 
+_RETRYABLE_ERRORS = (
+    RateLimitError,
+    APIConnectionError,
+    APITimeoutError,
+    InternalServerError,
+)
+
+
+def _parse_retry_after(exc: BaseException, *, fallback: float) -> float:
+    """Extract Retry-After header from an API error, or return fallback."""
+    import contextlib
+
+    response = getattr(exc, "response", None)
+    if response is not None:
+        header = getattr(response, "headers", {}).get("retry-after")
+        if header is not None:
+            with contextlib.suppress(ValueError, TypeError):
+                return float(header)
+    return fallback
+
+
+async def _embed_with_retry(
+    client: AzureOpenAIEmbeddings,
+    texts: list[str],
+    user_id: str,
+    batch_num: int,
+    total_batches: int,
+) -> list[list[float]]:
+    """Embed texts with exponential backoff retry on transient errors."""
+    delay = settings.embedding_retry_initial_delay
+    for attempt in range(1, settings.embedding_max_retries + 1):
+        try:
+            return await client.aembed_documents(texts)
+        except _RETRYABLE_ERRORS as exc:
+            if attempt == settings.embedding_max_retries:
+                logger.error(
+                    "Batch %d/%d: max retries exhausted for user %s",
+                    batch_num,
+                    total_batches,
+                    user_id,
+                )
+                raise
+            # Respect Retry-After header when present
+            wait = _parse_retry_after(exc, fallback=delay)
+            logger.warning(
+                "Batch %d/%d: %s (attempt %d/%d), retrying in %.1fs for user %s",
+                batch_num,
+                total_batches,
+                type(exc).__name__,
+                attempt,
+                settings.embedding_max_retries,
+                wait,
+                user_id,
+            )
+            await asyncio.sleep(wait)
+            delay *= 2
+    raise RuntimeError("unreachable")
+
+
 async def process_events(user_id: str, events: list[dict[str, Any]]) -> list[str]:
-    """Embed calendar events and upsert to the search index.
+    """Embed calendar events in batches and upsert to the search index.
 
     Handles both creates and updates — upsert semantics overwrite
     existing documents with the same source_id.
@@ -131,16 +201,52 @@ async def process_events(user_id: str, events: list[dict[str, Any]]) -> list[str
     if not events:
         return []
 
-    texts = [format_event_text(event) for event in events]
+    batch_size = settings.embedding_batch_size
     client = get_embeddings_client()
-    embeddings = await client.aembed_documents(texts)
+    all_ids: list[str] = []
+    total_batches = -(-len(events) // batch_size)
 
-    documents = [
-        build_search_document(event, text, embedding)
-        for event, text, embedding in zip(events, texts, embeddings, strict=True)
-    ]
+    for i in range(0, len(events), batch_size):
+        batch_events = events[i : i + batch_size]
+        batch_num = i // batch_size + 1
 
-    return await upsert_documents(user_id, documents)
+        texts = [format_event_text(event) for event in batch_events]
+        embeddings = await _embed_with_retry(
+            client, texts, user_id, batch_num, total_batches
+        )
+
+        documents = [
+            build_search_document(event, text, embedding)
+            for event, text, embedding in zip(
+                batch_events, texts, embeddings, strict=True
+            )
+        ]
+
+        ids = await upsert_documents(user_id, documents)
+        all_ids.extend(ids)
+
+        if len(ids) < len(batch_events):
+            logger.warning(
+                "Batch %d/%d: %d/%d upserts failed for user %s",
+                batch_num,
+                total_batches,
+                len(batch_events) - len(ids),
+                len(batch_events),
+                user_id,
+            )
+
+        logger.info(
+            "Batch %d/%d: embedded %d events for user %s",
+            batch_num,
+            total_batches,
+            len(batch_events),
+            user_id,
+        )
+
+        if batch_num < total_batches:
+            await asyncio.sleep(settings.embedding_batch_delay)
+
+    return all_ids
 
 
 async def delete_events(user_id: str, source_ids: list[str]) -> list[str]:

--- a/backend/app/search/embeddings.py
+++ b/backend/app/search/embeddings.py
@@ -234,15 +234,29 @@ async def process_events(user_id: str, events: list[dict[str, Any]]) -> list[str
         ids = await upsert_documents(user_id, documents)
         all_ids.extend(ids)
 
-        if len(ids) < len(batch_events):
-            logger.warning(
-                "Batch %d/%d: %d/%d upserts failed for user %s",
-                batch_num,
-                total_batches,
-                len(batch_events) - len(ids),
-                len(batch_events),
-                user_id,
-            )
+        # Retry any documents that failed to upsert (partial success / HTTP 207)
+        if len(ids) < len(documents):
+            succeeded_set = set(ids)
+            failed_docs = [d for d in documents if d["id"] not in succeeded_set]
+            retry_delay = settings.embedding_retry_initial_delay
+            for _retry in range(settings.embedding_max_retries):
+                if not failed_docs:
+                    break
+                await asyncio.sleep(retry_delay)
+                retry_ids = await upsert_documents(user_id, failed_docs)
+                all_ids.extend(retry_ids)
+                retried_set = set(retry_ids)
+                failed_docs = [d for d in failed_docs if d["id"] not in retried_set]
+                retry_delay *= 2
+            if failed_docs:
+                logger.warning(
+                    "Batch %d/%d: %d documents failed after retries for user %s: %s",
+                    batch_num,
+                    total_batches,
+                    len(failed_docs),
+                    user_id,
+                    [d["id"] for d in failed_docs],
+                )
 
         logger.info(
             "Batch %d/%d: embedded %d events for user %s",

--- a/backend/app/search/embeddings.py
+++ b/backend/app/search/embeddings.py
@@ -7,6 +7,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
+import httpx
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from langchain_openai import AzureOpenAIEmbeddings
 from openai import (
@@ -29,6 +30,11 @@ def get_embeddings_client() -> AzureOpenAIEmbeddings:
     """Return the singleton AzureOpenAIEmbeddings, creating on first call."""
     global _embeddings_client, _credential
     if _embeddings_client is None:
+        if not settings.azure_openai_endpoint:
+            raise RuntimeError(
+                "AZURE_OPENAI_ENDPOINT is not configured — "
+                "cannot create embeddings client"
+            )
         _credential = DefaultAzureCredential(
             managed_identity_client_id=settings.azure_managed_identity_client_id
             or None,
@@ -164,6 +170,9 @@ async def _embed_with_retry(
         try:
             return await client.aembed_documents(texts)
         except _RETRYABLE_ERRORS as exc:
+            # Don't retry permanent config errors (e.g., missing endpoint URL)
+            if isinstance(exc.__cause__, httpx.UnsupportedProtocol):
+                raise
             if attempt == settings.embedding_max_retries:
                 logger.error(
                     "Batch %d/%d: max retries exhausted for user %s",

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
+from azure.core.exceptions import HttpResponseError, ServiceRequestError
 from azure.identity.aio import DefaultAzureCredential
 from azure.search.documents.aio import SearchClient
 from azure.search.documents.models import VectorizedQuery, VectorQuery
@@ -110,6 +112,19 @@ async def search(
     return [dict(result) async for result in results]
 
 
+_RETRYABLE_STATUS_CODES = (429, 500, 503)
+
+
+def _is_retryable_search_error(exc: BaseException) -> bool:
+    """Check if an Azure Search error is transient and retryable."""
+    if isinstance(exc, ServiceRequestError):
+        return True
+    return (
+        isinstance(exc, HttpResponseError)
+        and exc.status_code in _RETRYABLE_STATUS_CODES
+    )
+
+
 async def upsert_documents(user_id: str, documents: list[dict[str, Any]]) -> list[str]:
     """Upsert documents into the search index with user_id enforcement.
 
@@ -122,10 +137,36 @@ async def upsert_documents(user_id: str, documents: list[dict[str, Any]]) -> lis
     _validate_user_id(user_id)
 
     docs_with_user = [{**doc, "user_id": user_id} for doc in documents]
-
     client = get_search_client()
-    results = await client.merge_or_upload_documents(docs_with_user)
-    return [r.key for r in results if r.succeeded and r.key is not None]
+
+    delay = settings.embedding_retry_initial_delay
+    for attempt in range(1, settings.embedding_max_retries + 1):
+        try:
+            results = await client.merge_or_upload_documents(docs_with_user)
+            succeeded = [r.key for r in results if r.succeeded and r.key is not None]
+            logger.info(
+                "Upserted %d/%d documents for user %s",
+                len(succeeded),
+                len(documents),
+                user_id,
+            )
+            return succeeded
+        except (HttpResponseError, ServiceRequestError) as exc:
+            is_last = attempt == settings.embedding_max_retries
+            if not _is_retryable_search_error(exc) or is_last:
+                logger.error("Upsert failed for user %s: %s", user_id, exc)
+                raise
+            logger.warning(
+                "Upsert attempt %d/%d failed for user %s: %s, retrying in %.1fs",
+                attempt,
+                settings.embedding_max_retries,
+                user_id,
+                type(exc).__name__,
+                delay,
+            )
+            await asyncio.sleep(delay)
+            delay *= 2
+    raise RuntimeError("unreachable")
 
 
 async def delete_documents(user_id: str, document_ids: list[str]) -> list[str]:
@@ -137,5 +178,32 @@ async def delete_documents(user_id: str, document_ids: list[str]) -> list[str]:
 
     client = get_search_client()
     docs_to_delete = [{"id": doc_id} for doc_id in document_ids]
-    results = await client.delete_documents(docs_to_delete)
-    return [r.key for r in results if r.succeeded and r.key is not None]
+
+    delay = settings.embedding_retry_initial_delay
+    for attempt in range(1, settings.embedding_max_retries + 1):
+        try:
+            results = await client.delete_documents(docs_to_delete)
+            succeeded = [r.key for r in results if r.succeeded and r.key is not None]
+            logger.info(
+                "Deleted %d/%d documents for user %s",
+                len(succeeded),
+                len(document_ids),
+                user_id,
+            )
+            return succeeded
+        except (HttpResponseError, ServiceRequestError) as exc:
+            is_last = attempt == settings.embedding_max_retries
+            if not _is_retryable_search_error(exc) or is_last:
+                logger.error("Delete failed for user %s: %s", user_id, exc)
+                raise
+            logger.warning(
+                "Delete attempt %d/%d failed for user %s: %s, retrying in %.1fs",
+                attempt,
+                settings.embedding_max_retries,
+                user_id,
+                type(exc).__name__,
+                delay,
+            )
+            await asyncio.sleep(delay)
+            delay *= 2
+    raise RuntimeError("unreachable")

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -23,6 +23,10 @@ def get_search_client() -> SearchClient:
     """Return the singleton async SearchClient, creating on first call."""
     global _search_client, _credential
     if _search_client is None:
+        if not settings.azure_search_endpoint:
+            raise RuntimeError(
+                "AZURE_SEARCH_ENDPOINT is not configured — cannot create search client"
+            )
         _credential = DefaultAzureCredential(
             managed_identity_client_id=settings.azure_managed_identity_client_id
             or None,

--- a/backend/tests/test_context_ingestion.py
+++ b/backend/tests/test_context_ingestion.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -607,3 +608,16 @@ class TestRunIngestion:
 
         # Should not raise — errors are logged and swallowed
         await run_ingestion("user-123")
+
+    @patch("app.context_ingestion.tasks.full_ingest", new_callable=AsyncMock)
+    @patch("app.context_ingestion.tasks.get_sync_metadata", new_callable=AsyncMock)
+    async def test_should_propagate_cancelled_error(
+        self, mock_get_meta: AsyncMock, mock_full: AsyncMock
+    ) -> None:
+        from app.context_ingestion.tasks import run_ingestion
+
+        mock_get_meta.return_value = None
+        mock_full.side_effect = asyncio.CancelledError()
+
+        with pytest.raises(asyncio.CancelledError):
+            await run_ingestion("user-123")

--- a/backend/tests/test_context_ingestion.py
+++ b/backend/tests/test_context_ingestion.py
@@ -333,7 +333,7 @@ class TestFullIngest:
     @patch("app.context_ingestion.sync.ingest_events", new_callable=AsyncMock)
     @patch("app.context_ingestion.sync._fetch_all_events", new_callable=AsyncMock)
     @patch("app.context_ingestion.sync._get_calendar_service", new_callable=AsyncMock)
-    async def test_should_store_sync_metadata_after_success(
+    async def test_should_store_metadata_before_ingest(
         self,
         mock_service: AsyncMock,
         mock_fetch: AsyncMock,
@@ -342,6 +342,16 @@ class TestFullIngest:
     ) -> None:
         from app.context_ingestion.sync import full_ingest
 
+        call_order: list[str] = []
+
+        def track_store(*a: Any, **kw: Any) -> None:
+            call_order.append("store")
+
+        def track_ingest(*a: Any, **kw: Any) -> None:
+            call_order.append("ingest")
+
+        mock_store_meta.side_effect = track_store
+        mock_ingest.side_effect = track_ingest
         mock_fetch.return_value = ([], "sync-tok-new")
 
         await full_ingest("user-123")
@@ -352,6 +362,30 @@ class TestFullIngest:
         metadata: SyncMetadata = call_args[0][1]
         assert metadata.sync_token == "sync-tok-new"
         assert metadata.last_ingested_at > 0
+        assert call_order == ["store", "ingest"]
+
+    @patch("app.context_ingestion.sync.store_sync_metadata", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync.ingest_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._fetch_all_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._get_calendar_service", new_callable=AsyncMock)
+    async def test_should_store_metadata_even_when_ingest_fails(
+        self,
+        mock_service: AsyncMock,
+        mock_fetch: AsyncMock,
+        mock_ingest: AsyncMock,
+        mock_store_meta: AsyncMock,
+    ) -> None:
+        from app.context_ingestion.sync import full_ingest
+
+        mock_fetch.return_value = ([_make_event()], "sync-tok-new")
+        mock_ingest.side_effect = RuntimeError("rate limit exceeded")
+
+        with pytest.raises(RuntimeError, match="rate limit exceeded"):
+            await full_ingest("user-123")
+
+        mock_store_meta.assert_awaited_once()
+        metadata: SyncMetadata = mock_store_meta.call_args[0][1]
+        assert metadata.sync_token == "sync-tok-new"
 
     @patch("app.context_ingestion.sync.store_sync_metadata", new_callable=AsyncMock)
     @patch("app.context_ingestion.sync.ingest_events", new_callable=AsyncMock)
@@ -508,7 +542,7 @@ class TestDeltaSync:
     @patch("app.context_ingestion.sync.ingest_events", new_callable=AsyncMock)
     @patch("app.context_ingestion.sync._fetch_all_events", new_callable=AsyncMock)
     @patch("app.context_ingestion.sync._get_calendar_service", new_callable=AsyncMock)
-    async def test_should_store_new_sync_token(
+    async def test_should_store_new_sync_token_before_ingest(
         self,
         mock_service: AsyncMock,
         mock_fetch: AsyncMock,
@@ -517,6 +551,16 @@ class TestDeltaSync:
     ) -> None:
         from app.context_ingestion.sync import delta_sync
 
+        call_order: list[str] = []
+
+        def track_store(*a: Any, **kw: Any) -> None:
+            call_order.append("store")
+
+        def track_ingest(*a: Any, **kw: Any) -> None:
+            call_order.append("ingest")
+
+        mock_store_meta.side_effect = track_store
+        mock_ingest.side_effect = track_ingest
         mock_fetch.return_value = ([], "brand-new-tok")
         metadata = SyncMetadata(sync_token="old-tok", last_ingested_at=1710000000)
 
@@ -526,6 +570,31 @@ class TestDeltaSync:
         stored: SyncMetadata = mock_store_meta.call_args[0][1]
         assert stored.sync_token == "brand-new-tok"
         assert stored.last_ingested_at > 0
+        assert call_order == ["store", "ingest"]
+
+    @patch("app.context_ingestion.sync.store_sync_metadata", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync.ingest_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._fetch_all_events", new_callable=AsyncMock)
+    @patch("app.context_ingestion.sync._get_calendar_service", new_callable=AsyncMock)
+    async def test_should_store_metadata_even_when_ingest_fails(
+        self,
+        mock_service: AsyncMock,
+        mock_fetch: AsyncMock,
+        mock_ingest: AsyncMock,
+        mock_store_meta: AsyncMock,
+    ) -> None:
+        from app.context_ingestion.sync import delta_sync
+
+        mock_fetch.return_value = ([_make_event()], "new-tok")
+        mock_ingest.side_effect = RuntimeError("rate limit exceeded")
+        metadata = SyncMetadata(sync_token="old-tok", last_ingested_at=1710000000)
+
+        with pytest.raises(RuntimeError, match="rate limit exceeded"):
+            await delta_sync("user-123", metadata)
+
+        mock_store_meta.assert_awaited_once()
+        stored: SyncMetadata = mock_store_meta.call_args[0][1]
+        assert stored.sync_token == "new-tok"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -856,6 +856,101 @@ class TestEmbedWithRetry:
 
 
 # ---------------------------------------------------------------------------
+# process_events — partial upsert retry
+# ---------------------------------------------------------------------------
+
+
+class TestProcessEventsPartialUpsertRetry:
+    @pytest.fixture(autouse=True)
+    def _reset(self) -> None:
+        from app.search.embeddings import reset_embeddings_client
+
+        reset_embeddings_client()
+
+    @patch("app.search.embeddings.upsert_documents", new_callable=AsyncMock)
+    @patch("app.search.embeddings.get_embeddings_client")
+    @patch("app.search.embeddings.settings")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_should_retry_partially_failed_upserts(
+        self,
+        mock_sleep: AsyncMock,
+        mock_settings: MagicMock,
+        mock_get_client: MagicMock,
+        mock_upsert: AsyncMock,
+    ) -> None:
+        from app.search.embeddings import process_events
+
+        mock_settings.embedding_batch_size = 50
+        mock_settings.embedding_batch_delay = 1.0
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+        mock_settings.embedding_max_text_length = 5000
+
+        mock_client = AsyncMock()
+        mock_client.aembed_documents = AsyncMock(return_value=[[0.1] * 1536] * 3)
+        mock_get_client.return_value = mock_client
+
+        # First upsert: 2/3 succeed; retry: remaining 1 succeeds
+        mock_upsert.side_effect = [
+            ["evt-1", "evt-2"],  # initial: evt-3 failed
+            ["evt-3"],  # retry: evt-3 succeeds
+        ]
+
+        events = [_make_event(event_id=f"evt-{i + 1}") for i in range(3)]
+        result = await process_events(user_id="user-123", events=events)
+
+        assert sorted(result) == ["evt-1", "evt-2", "evt-3"]
+        assert mock_upsert.await_count == 2
+
+        # Retry call should only contain the failed document
+        retry_call_docs = mock_upsert.call_args_list[1].args[1]
+        assert len(retry_call_docs) == 1
+        assert retry_call_docs[0]["id"] == "evt-3"
+
+    @patch("app.search.embeddings.upsert_documents", new_callable=AsyncMock)
+    @patch("app.search.embeddings.get_embeddings_client")
+    @patch("app.search.embeddings.settings")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_should_give_up_after_max_retries_for_failed_upserts(
+        self,
+        mock_sleep: AsyncMock,
+        mock_settings: MagicMock,
+        mock_get_client: MagicMock,
+        mock_upsert: AsyncMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from app.search.embeddings import process_events
+
+        mock_settings.embedding_batch_size = 50
+        mock_settings.embedding_batch_delay = 1.0
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+        mock_settings.embedding_max_text_length = 5000
+
+        mock_client = AsyncMock()
+        mock_client.aembed_documents = AsyncMock(return_value=[[0.1] * 1536] * 3)
+        mock_get_client.return_value = mock_client
+
+        # Initial: evt-3 fails; all retries also fail
+        mock_upsert.side_effect = [
+            ["evt-1", "evt-2"],  # initial
+            [],  # retry 1
+            [],  # retry 2
+            [],  # retry 3
+        ]
+
+        events = [_make_event(event_id=f"evt-{i + 1}") for i in range(3)]
+        with caplog.at_level(logging.WARNING):
+            result = await process_events(user_id="user-123", events=events)
+
+        assert result == ["evt-1", "evt-2"]
+        # 1 initial + 3 retries
+        assert mock_upsert.await_count == 4
+        assert "failed after retries" in caplog.text
+        assert "evt-3" in caplog.text
+
+
+# ---------------------------------------------------------------------------
 # format_event_text — truncation
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -50,6 +50,7 @@ class TestEmbeddingsClientLifecycle:
 
         reset_embeddings_client()
 
+    @patch("app.search.embeddings.settings")
     @patch("app.search.embeddings.AzureOpenAIEmbeddings")
     @patch("app.search.embeddings.get_bearer_token_provider")
     @patch("app.search.embeddings.DefaultAzureCredential")
@@ -58,9 +59,14 @@ class TestEmbeddingsClientLifecycle:
         mock_cred_cls: MagicMock,
         mock_token_provider: MagicMock,
         mock_embeddings_cls: MagicMock,
+        mock_settings: MagicMock,
     ) -> None:
-        from app.core.config import settings
         from app.search.embeddings import get_embeddings_client
+
+        mock_settings.azure_openai_endpoint = "https://test.openai.azure.com"
+        mock_settings.azure_openai_embed_deployment = "text-embedding-3-small"
+        mock_settings.azure_openai_api_version = "2024-10-21"
+        mock_settings.azure_managed_identity_client_id = ""
 
         mock_cred = MagicMock()
         mock_cred_cls.return_value = mock_cred
@@ -75,11 +81,12 @@ class TestEmbeddingsClientLifecycle:
         )
         mock_embeddings_cls.assert_called_once()
         call_kwargs = mock_embeddings_cls.call_args.kwargs
-        assert call_kwargs["azure_endpoint"] == settings.azure_openai_endpoint
-        assert call_kwargs["deployment"] == settings.azure_openai_embed_deployment
-        assert call_kwargs["openai_api_version"] == settings.azure_openai_api_version
+        assert call_kwargs["azure_endpoint"] == "https://test.openai.azure.com"
+        assert call_kwargs["deployment"] == "text-embedding-3-small"
+        assert call_kwargs["openai_api_version"] == "2024-10-21"
         assert client is mock_embeddings_cls.return_value
 
+    @patch("app.search.embeddings.settings")
     @patch("app.search.embeddings.AzureOpenAIEmbeddings")
     @patch("app.search.embeddings.get_bearer_token_provider")
     @patch("app.search.embeddings.DefaultAzureCredential")
@@ -88,9 +95,12 @@ class TestEmbeddingsClientLifecycle:
         mock_cred_cls: MagicMock,
         mock_token_provider: MagicMock,
         mock_embeddings_cls: MagicMock,
+        mock_settings: MagicMock,
     ) -> None:
         from app.search.embeddings import get_embeddings_client
 
+        mock_settings.azure_openai_endpoint = "https://test.openai.azure.com"
+        mock_settings.azure_managed_identity_client_id = ""
         mock_embeddings_cls.return_value = MagicMock()
 
         first = get_embeddings_client()
@@ -99,6 +109,7 @@ class TestEmbeddingsClientLifecycle:
         assert first is second
         mock_embeddings_cls.assert_called_once()
 
+    @patch("app.search.embeddings.settings")
     @patch("app.search.embeddings.AzureOpenAIEmbeddings")
     @patch("app.search.embeddings.get_bearer_token_provider")
     @patch("app.search.embeddings.DefaultAzureCredential")
@@ -107,9 +118,12 @@ class TestEmbeddingsClientLifecycle:
         mock_cred_cls: MagicMock,
         mock_token_provider: MagicMock,
         mock_embeddings_cls: MagicMock,
+        mock_settings: MagicMock,
     ) -> None:
         from app.search.embeddings import close_embeddings_client, get_embeddings_client
 
+        mock_settings.azure_openai_endpoint = "https://test.openai.azure.com"
+        mock_settings.azure_managed_identity_client_id = ""
         mock_cred = MagicMock()
         mock_cred_cls.return_value = mock_cred
         mock_embeddings_cls.return_value = MagicMock()
@@ -127,6 +141,15 @@ class TestEmbeddingsClientLifecycle:
         from app.search.embeddings import close_embeddings_client
 
         close_embeddings_client()
+
+    @patch("app.search.embeddings.settings")
+    def test_should_reject_empty_endpoint(self, mock_settings: MagicMock) -> None:
+        from app.search.embeddings import get_embeddings_client
+
+        mock_settings.azure_openai_endpoint = ""
+
+        with pytest.raises(RuntimeError, match="AZURE_OPENAI_ENDPOINT"):
+            get_embeddings_client()
 
 
 class TestFormatEventText:

--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
+import openai
 import pytest
 
 
@@ -402,3 +405,446 @@ class TestDeleteEvents:
 
         result = await delete_events(user_id="user-123", source_ids=[])
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Helpers for constructing openai errors in tests
+# ---------------------------------------------------------------------------
+
+
+def _make_rate_limit_error(
+    retry_after: str | None = None,
+) -> openai.RateLimitError:
+    """Build an openai.RateLimitError for testing."""
+    headers: dict[str, str] = {}
+    if retry_after is not None:
+        headers["retry-after"] = retry_after
+    response = httpx.Response(
+        429,
+        headers=headers,
+        request=httpx.Request("POST", "https://fake.openai.azure.com"),
+    )
+    return openai.RateLimitError(
+        message="Rate limit exceeded",
+        response=response,
+        body={"error": {"message": "rate limited"}},
+    )
+
+
+def _make_connection_error() -> openai.APIConnectionError:
+    """Build an openai.APIConnectionError for testing."""
+    return openai.APIConnectionError(
+        request=httpx.Request("POST", "https://fake.openai.azure.com"),
+    )
+
+
+def _make_bad_request_error() -> openai.BadRequestError:
+    """Build a non-transient openai.BadRequestError for testing."""
+    response = httpx.Response(
+        400,
+        request=httpx.Request("POST", "https://fake.openai.azure.com"),
+    )
+    return openai.BadRequestError(
+        message="Invalid input",
+        response=response,
+        body={"error": {"message": "bad request"}},
+    )
+
+
+# ---------------------------------------------------------------------------
+# process_events — batching behavior
+# ---------------------------------------------------------------------------
+
+
+class TestProcessEventsBatching:
+    @pytest.fixture(autouse=True)
+    def _reset(self) -> None:
+        from app.search.embeddings import reset_embeddings_client
+
+        reset_embeddings_client()
+
+    @patch("app.search.embeddings.upsert_documents", new_callable=AsyncMock)
+    @patch("app.search.embeddings.get_embeddings_client")
+    @patch("app.search.embeddings.settings")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_should_batch_events_according_to_batch_size(
+        self,
+        mock_sleep: AsyncMock,
+        mock_settings: MagicMock,
+        mock_get_client: MagicMock,
+        mock_upsert: AsyncMock,
+    ) -> None:
+        from app.search.embeddings import process_events
+
+        mock_settings.embedding_batch_size = 50
+        mock_settings.embedding_batch_delay = 1.0
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+        mock_settings.embedding_max_text_length = 5000
+
+        mock_client = AsyncMock()
+        mock_client.aembed_documents = AsyncMock(
+            side_effect=[
+                [[0.1] * 1536] * 50,
+                [[0.1] * 1536] * 50,
+                [[0.1] * 1536] * 20,
+            ]
+        )
+        mock_get_client.return_value = mock_client
+
+        mock_upsert.side_effect = [
+            [f"evt-{i}" for i in range(50)],
+            [f"evt-{i}" for i in range(50, 100)],
+            [f"evt-{i}" for i in range(100, 120)],
+        ]
+
+        events = [_make_event(event_id=f"evt-{i}") for i in range(120)]
+        await process_events(user_id="user-123", events=events)
+
+        assert mock_client.aembed_documents.await_count == 3
+
+    @patch("app.search.embeddings.upsert_documents", new_callable=AsyncMock)
+    @patch("app.search.embeddings.get_embeddings_client")
+    @patch("app.search.embeddings.settings")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_should_process_single_batch_when_events_fit(
+        self,
+        mock_sleep: AsyncMock,
+        mock_settings: MagicMock,
+        mock_get_client: MagicMock,
+        mock_upsert: AsyncMock,
+    ) -> None:
+        from app.search.embeddings import process_events
+
+        mock_settings.embedding_batch_size = 50
+        mock_settings.embedding_batch_delay = 1.0
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+        mock_settings.embedding_max_text_length = 5000
+
+        mock_client = AsyncMock()
+        mock_client.aembed_documents = AsyncMock(return_value=[[0.1] * 1536] * 30)
+        mock_get_client.return_value = mock_client
+        mock_upsert.return_value = [f"evt-{i}" for i in range(30)]
+
+        events = [_make_event(event_id=f"evt-{i}") for i in range(30)]
+        await process_events(user_id="user-123", events=events)
+
+        mock_client.aembed_documents.assert_awaited_once()
+
+    @patch("app.search.embeddings.upsert_documents", new_callable=AsyncMock)
+    @patch("app.search.embeddings.get_embeddings_client")
+    @patch("app.search.embeddings.settings")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_should_aggregate_upserted_ids_across_batches(
+        self,
+        mock_sleep: AsyncMock,
+        mock_settings: MagicMock,
+        mock_get_client: MagicMock,
+        mock_upsert: AsyncMock,
+    ) -> None:
+        from app.search.embeddings import process_events
+
+        mock_settings.embedding_batch_size = 50
+        mock_settings.embedding_batch_delay = 1.0
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+        mock_settings.embedding_max_text_length = 5000
+
+        mock_client = AsyncMock()
+        mock_client.aembed_documents = AsyncMock(
+            side_effect=[[[0.1] * 1536] * 50, [[0.1] * 1536] * 50]
+        )
+        mock_get_client.return_value = mock_client
+
+        mock_upsert.side_effect = [
+            [f"evt-{i}" for i in range(50)],
+            [f"evt-{i}" for i in range(50, 100)],
+        ]
+
+        events = [_make_event(event_id=f"evt-{i}") for i in range(100)]
+        result = await process_events(user_id="user-123", events=events)
+
+        assert len(result) == 100
+
+    @patch("app.search.embeddings.upsert_documents", new_callable=AsyncMock)
+    @patch("app.search.embeddings.get_embeddings_client")
+    @patch("app.search.embeddings.settings")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_should_upsert_each_batch_separately(
+        self,
+        mock_sleep: AsyncMock,
+        mock_settings: MagicMock,
+        mock_get_client: MagicMock,
+        mock_upsert: AsyncMock,
+    ) -> None:
+        from app.search.embeddings import process_events
+
+        mock_settings.embedding_batch_size = 50
+        mock_settings.embedding_batch_delay = 1.0
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+        mock_settings.embedding_max_text_length = 5000
+
+        mock_client = AsyncMock()
+        mock_client.aembed_documents = AsyncMock(
+            side_effect=[[[0.1] * 1536] * 50, [[0.1] * 1536] * 50]
+        )
+        mock_get_client.return_value = mock_client
+
+        mock_upsert.side_effect = [
+            [f"evt-{i}" for i in range(50)],
+            [f"evt-{i}" for i in range(50, 100)],
+        ]
+
+        events = [_make_event(event_id=f"evt-{i}") for i in range(100)]
+        await process_events(user_id="user-123", events=events)
+
+        assert mock_upsert.await_count == 2
+
+    @patch("app.search.embeddings.upsert_documents", new_callable=AsyncMock)
+    @patch("app.search.embeddings.get_embeddings_client")
+    @patch("app.search.embeddings.settings")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_should_delay_between_batches(
+        self,
+        mock_sleep: AsyncMock,
+        mock_settings: MagicMock,
+        mock_get_client: MagicMock,
+        mock_upsert: AsyncMock,
+    ) -> None:
+        from app.search.embeddings import process_events
+
+        mock_settings.embedding_batch_size = 50
+        mock_settings.embedding_batch_delay = 2.0
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+        mock_settings.embedding_max_text_length = 5000
+
+        mock_client = AsyncMock()
+        mock_client.aembed_documents = AsyncMock(
+            side_effect=[[[0.1] * 1536] * 50, [[0.1] * 1536] * 50]
+        )
+        mock_get_client.return_value = mock_client
+        mock_upsert.side_effect = [
+            [f"evt-{i}" for i in range(50)],
+            [f"evt-{i}" for i in range(50, 100)],
+        ]
+
+        events = [_make_event(event_id=f"evt-{i}") for i in range(100)]
+        await process_events(user_id="user-123", events=events)
+
+        # Should sleep between batch 1 and batch 2, but not after batch 2
+        mock_sleep.assert_awaited_once_with(2.0)
+
+    @patch("app.search.embeddings.upsert_documents", new_callable=AsyncMock)
+    @patch("app.search.embeddings.get_embeddings_client")
+    @patch("app.search.embeddings.settings")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_should_log_batch_progress(
+        self,
+        mock_sleep: AsyncMock,
+        mock_settings: MagicMock,
+        mock_get_client: MagicMock,
+        mock_upsert: AsyncMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from app.search.embeddings import process_events
+
+        mock_settings.embedding_batch_size = 50
+        mock_settings.embedding_batch_delay = 1.0
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+        mock_settings.embedding_max_text_length = 5000
+
+        mock_client = AsyncMock()
+        mock_client.aembed_documents = AsyncMock(
+            side_effect=[[[0.1] * 1536] * 50, [[0.1] * 1536] * 20]
+        )
+        mock_get_client.return_value = mock_client
+        mock_upsert.side_effect = [
+            [f"evt-{i}" for i in range(50)],
+            [f"evt-{i}" for i in range(50, 70)],
+        ]
+
+        events = [_make_event(event_id=f"evt-{i}") for i in range(70)]
+        with caplog.at_level(logging.INFO):
+            await process_events(user_id="user-123", events=events)
+
+        assert "Batch 1/2: embedded 50 events for user user-123" in caplog.text
+        assert "Batch 2/2: embedded 20 events for user user-123" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _embed_with_retry — retry and backoff behavior
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedWithRetry:
+    @pytest.fixture(autouse=True)
+    def _reset(self) -> None:
+        from app.search.embeddings import reset_embeddings_client
+
+        reset_embeddings_client()
+
+    @patch("app.search.embeddings.settings")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_should_retry_on_rate_limit_error(
+        self, mock_sleep: AsyncMock, mock_settings: MagicMock
+    ) -> None:
+        from app.search.embeddings import (
+            _embed_with_retry,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+
+        mock_client = AsyncMock()
+        mock_client.aembed_documents = AsyncMock(
+            side_effect=[_make_rate_limit_error(), [[0.1] * 1536]]
+        )
+
+        result = await _embed_with_retry(
+            mock_client, ["text"], "user-123", batch_num=1, total_batches=1
+        )
+
+        assert result == [[0.1] * 1536]
+        assert mock_client.aembed_documents.await_count == 2
+
+    @patch("app.search.embeddings.settings")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_should_retry_on_connection_error(
+        self, mock_sleep: AsyncMock, mock_settings: MagicMock
+    ) -> None:
+        from app.search.embeddings import (
+            _embed_with_retry,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+
+        mock_client = AsyncMock()
+        mock_client.aembed_documents = AsyncMock(
+            side_effect=[_make_connection_error(), [[0.1] * 1536]]
+        )
+
+        result = await _embed_with_retry(
+            mock_client, ["text"], "user-123", batch_num=1, total_batches=1
+        )
+
+        assert result == [[0.1] * 1536]
+        assert mock_client.aembed_documents.await_count == 2
+
+    @patch("app.search.embeddings.settings")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_should_raise_after_max_retries_exhausted(
+        self, mock_sleep: AsyncMock, mock_settings: MagicMock
+    ) -> None:
+        from app.search.embeddings import (
+            _embed_with_retry,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+
+        mock_client = AsyncMock()
+        mock_client.aembed_documents = AsyncMock(side_effect=_make_rate_limit_error())
+
+        with pytest.raises(openai.RateLimitError):
+            await _embed_with_retry(
+                mock_client, ["text"], "user-123", batch_num=1, total_batches=1
+            )
+
+        assert mock_client.aembed_documents.await_count == 3
+
+    @patch("app.search.embeddings.settings")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_should_not_retry_on_non_transient_errors(
+        self, mock_sleep: AsyncMock, mock_settings: MagicMock
+    ) -> None:
+        from app.search.embeddings import (
+            _embed_with_retry,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+
+        mock_client = AsyncMock()
+        mock_client.aembed_documents = AsyncMock(side_effect=_make_bad_request_error())
+
+        with pytest.raises(openai.BadRequestError):
+            await _embed_with_retry(
+                mock_client, ["text"], "user-123", batch_num=1, total_batches=1
+            )
+
+        mock_client.aembed_documents.assert_awaited_once()
+
+    @patch("app.search.embeddings.settings")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_should_use_exponential_backoff_on_retry(
+        self, mock_sleep: AsyncMock, mock_settings: MagicMock
+    ) -> None:
+        from app.search.embeddings import (
+            _embed_with_retry,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+
+        mock_client = AsyncMock()
+        mock_client.aembed_documents = AsyncMock(
+            side_effect=[
+                _make_rate_limit_error(),
+                _make_rate_limit_error(),
+                [[0.1] * 1536],
+            ]
+        )
+
+        await _embed_with_retry(
+            mock_client, ["text"], "user-123", batch_num=1, total_batches=1
+        )
+
+        assert mock_sleep.await_count == 2
+        mock_sleep.assert_any_await(1.0)
+        mock_sleep.assert_any_await(2.0)
+
+    @patch("app.search.embeddings.settings")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_should_respect_retry_after_header(
+        self, mock_sleep: AsyncMock, mock_settings: MagicMock
+    ) -> None:
+        from app.search.embeddings import (
+            _embed_with_retry,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+
+        mock_client = AsyncMock()
+        mock_client.aembed_documents = AsyncMock(
+            side_effect=[_make_rate_limit_error(retry_after="30"), [[0.1] * 1536]]
+        )
+
+        await _embed_with_retry(
+            mock_client, ["text"], "user-123", batch_num=1, total_batches=1
+        )
+
+        mock_sleep.assert_awaited_once_with(30.0)
+
+
+# ---------------------------------------------------------------------------
+# format_event_text — truncation
+# ---------------------------------------------------------------------------
+
+
+class TestFormatEventTextTruncation:
+    @patch("app.search.embeddings.settings")
+    def test_should_truncate_long_description(self, mock_settings: MagicMock) -> None:
+        from app.search.embeddings import format_event_text
+
+        mock_settings.embedding_max_text_length = 100
+
+        event = _make_event(description="x" * 10000)
+        text = format_event_text(event)
+
+        assert len(text) <= 100

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -160,37 +160,55 @@ class TestSearchClientLifecycle:
 
         reset_search_client()
 
+    @patch("app.search.service.settings")
     @patch("app.search.service.DefaultAzureCredential")
     @patch("app.search.service.SearchClient")
     def test_get_search_client_returns_search_client(
-        self, mock_client_cls: MagicMock, mock_cred_cls: MagicMock
+        self,
+        mock_client_cls: MagicMock,
+        mock_cred_cls: MagicMock,
+        mock_settings: MagicMock,
     ) -> None:
         from app.search.service import get_search_client
 
+        mock_settings.azure_search_endpoint = "https://test.search.windows.net"
+        mock_settings.azure_managed_identity_client_id = ""
         mock_client_cls.return_value = MagicMock()
         result = get_search_client()
         assert result is mock_client_cls.return_value
 
+    @patch("app.search.service.settings")
     @patch("app.search.service.DefaultAzureCredential")
     @patch("app.search.service.SearchClient")
     def test_get_search_client_returns_same_instance(
-        self, mock_client_cls: MagicMock, mock_cred_cls: MagicMock
+        self,
+        mock_client_cls: MagicMock,
+        mock_cred_cls: MagicMock,
+        mock_settings: MagicMock,
     ) -> None:
         from app.search.service import get_search_client
 
+        mock_settings.azure_search_endpoint = "https://test.search.windows.net"
+        mock_settings.azure_managed_identity_client_id = ""
         mock_client_cls.return_value = MagicMock()
         first = get_search_client()
         second = get_search_client()
         assert first is second
         mock_client_cls.assert_called_once()
 
+    @patch("app.search.service.settings")
     @patch("app.search.service.DefaultAzureCredential")
     @patch("app.search.service.SearchClient")
     async def test_close_search_client_calls_close(
-        self, mock_client_cls: MagicMock, mock_cred_cls: MagicMock
+        self,
+        mock_client_cls: MagicMock,
+        mock_cred_cls: MagicMock,
+        mock_settings: MagicMock,
     ) -> None:
         from app.search.service import close_search_client, get_search_client
 
+        mock_settings.azure_search_endpoint = "https://test.search.windows.net"
+        mock_settings.azure_managed_identity_client_id = ""
         mock_client = AsyncMock()
         mock_client_cls.return_value = mock_client
         mock_cred = AsyncMock()
@@ -202,13 +220,19 @@ class TestSearchClientLifecycle:
         mock_client.close.assert_awaited_once()
         mock_cred.close.assert_awaited_once()
 
+    @patch("app.search.service.settings")
     @patch("app.search.service.DefaultAzureCredential")
     @patch("app.search.service.SearchClient")
     async def test_close_search_client_clears_singleton(
-        self, mock_client_cls: MagicMock, mock_cred_cls: MagicMock
+        self,
+        mock_client_cls: MagicMock,
+        mock_cred_cls: MagicMock,
+        mock_settings: MagicMock,
     ) -> None:
         from app.search.service import close_search_client, get_search_client
 
+        mock_settings.azure_search_endpoint = "https://test.search.windows.net"
+        mock_settings.azure_managed_identity_client_id = ""
         mock_client_cls.return_value = AsyncMock()
         mock_cred_cls.return_value = AsyncMock()
 
@@ -219,6 +243,15 @@ class TestSearchClientLifecycle:
         mock_client_cls.reset_mock()
         get_search_client()
         mock_client_cls.assert_called_once()
+
+    @patch("app.search.service.settings")
+    def test_should_reject_empty_endpoint(self, mock_settings: MagicMock) -> None:
+        from app.search.service import get_search_client
+
+        mock_settings.azure_search_endpoint = ""
+
+        with pytest.raises(RuntimeError, match="AZURE_SEARCH_ENDPOINT"):
+            get_search_client()
 
     async def test_close_search_client_safe_when_no_client(self) -> None:
         from app.search.service import close_search_client

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from azure.core.exceptions import HttpResponseError, ServiceRequestError
 
 from app.search.index import build_index_schema
 
@@ -525,3 +526,105 @@ class TestDeleteDocuments:
 
         with pytest.raises(ValueError, match="user_id"):
             await delete_documents(user_id="", document_ids=["doc1"])
+
+
+# ---------------------------------------------------------------------------
+# Retry behavior on upsert/delete
+# ---------------------------------------------------------------------------
+
+
+def _make_http_response_error(status_code: int = 429) -> HttpResponseError:
+    """Build an Azure HttpResponseError for testing."""
+    error = HttpResponseError(message=f"HTTP {status_code}")
+    error.status_code = status_code
+    return error
+
+
+class TestUpsertDocumentsRetry:
+    @pytest.fixture(autouse=True)
+    def _reset(self) -> None:
+        from app.search.service import reset_search_client
+
+        reset_search_client()
+
+    @patch("app.search.service.get_search_client")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    @patch("app.search.service.settings")
+    async def test_should_retry_upsert_on_transient_error(
+        self,
+        mock_settings: MagicMock,
+        mock_sleep: AsyncMock,
+        mock_get_client: MagicMock,
+    ) -> None:
+        from app.search.service import upsert_documents
+
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+
+        mock_result = MagicMock(succeeded=True, key="doc1")
+        mock_client = AsyncMock()
+        mock_client.merge_or_upload_documents = AsyncMock(
+            side_effect=[_make_http_response_error(429), [mock_result]]
+        )
+        mock_get_client.return_value = mock_client
+
+        result = await upsert_documents(
+            user_id="user-123", documents=[{"id": "doc1", "content": "test"}]
+        )
+
+        assert result == ["doc1"]
+        assert mock_client.merge_or_upload_documents.await_count == 2
+
+    @patch("app.search.service.get_search_client")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    @patch("app.search.service.settings")
+    async def test_should_raise_upsert_after_max_retries(
+        self,
+        mock_settings: MagicMock,
+        mock_sleep: AsyncMock,
+        mock_get_client: MagicMock,
+    ) -> None:
+        from app.search.service import upsert_documents
+
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+
+        mock_client = AsyncMock()
+        mock_client.merge_or_upload_documents = AsyncMock(
+            side_effect=_make_http_response_error(429)
+        )
+        mock_get_client.return_value = mock_client
+
+        with pytest.raises(HttpResponseError):
+            await upsert_documents(
+                user_id="user-123", documents=[{"id": "doc1", "content": "test"}]
+            )
+
+        assert mock_client.merge_or_upload_documents.await_count == 3
+
+    @patch("app.search.service.get_search_client")
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    @patch("app.search.service.settings")
+    async def test_should_retry_on_service_request_error(
+        self,
+        mock_settings: MagicMock,
+        mock_sleep: AsyncMock,
+        mock_get_client: MagicMock,
+    ) -> None:
+        from app.search.service import upsert_documents
+
+        mock_settings.embedding_max_retries = 3
+        mock_settings.embedding_retry_initial_delay = 1.0
+
+        mock_result = MagicMock(succeeded=True, key="doc1")
+        mock_client = AsyncMock()
+        mock_client.merge_or_upload_documents = AsyncMock(
+            side_effect=[ServiceRequestError("connection reset"), [mock_result]]
+        )
+        mock_get_client.return_value = mock_client
+
+        result = await upsert_documents(
+            user_id="user-123", documents=[{"id": "doc1", "content": "test"}]
+        )
+
+        assert result == ["doc1"]

--- a/backend/tests/test_search_tools.py
+++ b/backend/tests/test_search_tools.py
@@ -193,9 +193,7 @@ class TestSearchContext:
         mock_client.aembed_query = AsyncMock(side_effect=RuntimeError("API down"))
         mock_get_embed.return_value = mock_client
 
-        result = await search_context.ainvoke(
-            {"query": "test", "user_id": "user-123"}
-        )
+        result = await search_context.ainvoke({"query": "test", "user_id": "user-123"})
 
         assert isinstance(result, str)
         assert "search failed" in result.lower()
@@ -214,9 +212,7 @@ class TestSearchContext:
         mock_get_embed.return_value = mock_client
         mock_search.side_effect = RuntimeError("Search service down")
 
-        result = await search_context.ainvoke(
-            {"query": "test", "user_id": "user-123"}
-        )
+        result = await search_context.ainvoke({"query": "test", "user_id": "user-123"})
 
         assert isinstance(result, str)
         assert "search failed" in result.lower()
@@ -254,9 +250,7 @@ class TestSearchContext:
         mock_get_embed.return_value = mock_client
         mock_search.return_value = []
 
-        await search_context.ainvoke(
-            {"query": "test", "top": 0, "user_id": "user-123"}
-        )
+        await search_context.ainvoke({"query": "test", "top": 0, "user_id": "user-123"})
 
         assert mock_search.call_args.kwargs["top"] == 1
 

--- a/docs/TRADEOFFS.md
+++ b/docs/TRADEOFFS.md
@@ -74,3 +74,120 @@ Key details:
 
 - Scaling to 2+ backend replicas
 - Observing duplicate refresh calls in logs (`"Token refresh failed"` or `"Token refresh network error"` for the same user at the same timestamp)
+
+---
+
+## 2. Ingestion Sync Lock — None vs Distributed
+
+**Date:** 2026-03-16
+**Issue:** #92 (Embedding Pipeline Batching)
+**File:** `backend/app/context_ingestion/tasks.py`
+
+### The problem
+
+When a user logs in, `run_ingestion()` is enqueued as a FastAPI BackgroundTask. If the same user logs in from two browser tabs simultaneously, both tasks pass the cooldown check (which reads Redis but doesn't lock) and both call `full_ingest()` — doubling the embedding API calls and TPM consumption.
+
+### What we built (MVP)
+
+No lock. The cooldown check in `run_ingestion()` uses `get_sync_metadata()` to read the last-ingested timestamp from Redis, but the check-then-act sequence is not atomic. Two concurrent tasks can both see "cooldown elapsed" and proceed.
+
+### Why this is sufficient for now
+
+- Upsert semantics (`merge_or_upload_documents`) make concurrent writes safe — whichever finishes last simply overwrites with the same data
+- No data corruption or orphaned documents
+- The only cost is redundant Azure OpenAI embedding calls (TPM waste)
+- With the new batching + exponential backoff (#92), even redundant calls complete gracefully instead of crashing
+
+### When this breaks
+
+- High-traffic periods where many users log in simultaneously
+- Multiple backend replicas (each runs its own background tasks)
+- Low TPM quotas where redundant calls cause cascading 429 retries
+
+### The upgrade path — Redis distributed lock
+
+Same pattern as the token refresh lock (Tradeoff #1):
+
+```python
+lock_key = f"lock:ingestion:{user_id}"
+acquired = await redis.set(lock_key, "1", nx=True, ex=600)  # 10min TTL
+if acquired:
+    try:
+        await full_ingest(user_id)
+    finally:
+        await redis.delete(lock_key)
+else:
+    logger.info("Ingestion already running for user %s, skipping", user_id)
+```
+
+Key details:
+- `ex=600` — TTL matches max expected full ingest duration (10 minutes for 500+ events at 10K TPM)
+- If the holder crashes, the lock auto-releases after TTL
+- Skipping (not queuing) is the right behavior — next login will trigger a delta sync
+
+### Trigger to upgrade
+
+- Observing duplicate `"Starting full ingest for user X"` logs at the same timestamp
+- Scaling to 2+ backend replicas
+- Frequent 429 retries in logs when TPM quota is tight
+
+---
+
+## 3. Embedding Token Budget Tracking — Reactive vs Proactive
+
+**Date:** 2026-03-16
+**Issue:** #92 (Embedding Pipeline Batching)
+**File:** `backend/app/search/embeddings.py`
+
+### The problem
+
+The embedding pipeline has no visibility into how many tokens it consumes per batch. It only learns about TPM limits when Azure returns a 429 error, then reacts with exponential backoff. This is wasteful — each 429 response adds 1-60 seconds of retry delay.
+
+### What we built (MVP)
+
+Reactive rate limit handling:
+- Batch events into groups of 50 (configurable)
+- 1-second delay between batches (configurable)
+- Exponential backoff with retry on 429 (respects `Retry-After` header)
+- Progress logging per batch
+
+### Why this is sufficient for now
+
+- 10K TPM allows ~2.5 batches/minute of 50 short events (~80 tokens each)
+- The `Retry-After` header tells us exactly when to retry
+- Full ingest for a typical user (200-300 events) completes in 2-5 minutes
+- Backoff adds latency but doesn't cause data loss (background task, idempotent)
+
+### When this breaks
+
+- Events with long descriptions (meeting transcripts, agendas) consume 300-500 tokens each — 50-event batch could hit 25K tokens, exhausting 10K TPM in one call
+- Multiple users ingesting simultaneously share the same TPM quota
+- Users notice slow first-login experience due to repeated 429 retries
+
+### The upgrade path — Proactive token estimation
+
+Estimate tokens before sending each batch and pace requests to stay within budget:
+
+```python
+# chars/4 is a reasonable heuristic for English text → tokens
+estimated_tokens = sum(len(text) for text in batch_texts) // 4
+tokens_per_minute = settings.azure_openai_tpm_limit  # e.g. 10_000
+
+# Track cumulative usage in a sliding window
+if cumulative_tokens + estimated_tokens > tokens_per_minute:
+    wait = 60 - elapsed_since_window_start
+    await asyncio.sleep(wait)
+    reset_window()
+```
+
+Key details:
+- `chars/4` heuristic is ~80% accurate for English text
+- Sliding window tracks tokens consumed in the current minute
+- Proactive delay avoids 429 entirely — no wasted retry cycles
+- Could also use `tiktoken` for exact counts (adds ~1ms per batch)
+
+### Trigger to upgrade
+
+- Frequent 429 retries visible in batch progress logs (e.g., `"retrying in 30.0s"`)
+- User complaints about slow first-login experience
+- TPM quota increase is not an option (cost or policy constraint)

--- a/docs/TRADEOFFS.md
+++ b/docs/TRADEOFFS.md
@@ -191,3 +191,132 @@ Key details:
 - Frequent 429 retries visible in batch progress logs (e.g., `"retrying in 30.0s"`)
 - User complaints about slow first-login experience
 - TPM quota increase is not an option (cost or policy constraint)
+
+---
+
+## 4. Embedding Cost & TPM Scaling — Redis as Sync Token Store
+
+**Date:** 2026-03-16
+**Issue:** #92 (Embedding Pipeline Batching)
+**Files:** `backend/app/context_ingestion/sync.py`, `backend/app/search/embeddings.py`
+
+### Baseline numbers (real measurement)
+
+Single user calendar: **162 events, 143.73K tokens, ~4 batches of 50**
+
+- Average tokens per event: ~887
+- Embedding model: `text-embedding-3-small` ($0.02 / 1M tokens)
+- Cost per full ingest: **$0.0029**
+
+### Cost at scale
+
+| Users | Full ingest tokens | Cost | Notes |
+|-------|--------------------|------|-------|
+| 1 | 143.73K | $0.003 | Your calendar |
+| 10 | 1.44M | $0.03 | Small team |
+| 100 | 14.4M | $0.29 | Department |
+| 1,000 | 144M | $2.88 | Organization |
+
+Embeddings are cheap. **The real constraint is TPM (tokens per minute)**, not dollars.
+
+### TPM bottleneck
+
+Azure OpenAI enforces TPM quotas per deployment:
+
+| Tier | TPM limit | Full ingests/min (at 144K tokens each) |
+|------|-----------|----------------------------------------|
+| S0 default | 240K | 1.6 users |
+| S0 increased | 1M | 6.9 users |
+| Provisioned | 10M | 69 users |
+
+Delta sync (typically ~5 changed events, ~4.4K tokens) is **~33x cheaper** than full ingest per login. The sync token in Redis is what enables delta sync — losing it forces a full re-ingest.
+
+### What we built (MVP)
+
+Sync tokens live in Redis only. If Redis data is lost:
+
+1. `get_sync_metadata()` returns `None` for every user
+2. Every login triggers `full_ingest()` instead of `delta_sync()`
+3. All users compete for the same TPM quota simultaneously
+
+### The re-ingest storm
+
+If Redis dies and N users log in:
+
+| Users | Tokens needed | Time at 240K TPM | Time at 1M TPM | Time at 10M TPM |
+|-------|---------------|-------------------|-----------------|-----------------|
+| 10 | 1.44M | 6 min | 1.4 min | 9 sec |
+| 100 | 14.4M | 60 min | 14.4 min | 1.4 min |
+| 1,000 | 144M | 10 hours | 2.4 hours | 14.4 min |
+
+With batching + exponential backoff, this degrades gracefully (no crashes, just slow). Each user takes 6-8 seconds without rate limits, 30-120 seconds with backoff retries.
+
+### Why this is sufficient for now
+
+- Azure Cache for Redis (managed) has 99.9% SLA — full data loss is rare
+- At MVP scale (1-10 users), a re-ingest storm is 1.44M tokens / ~$0.03 / ~6 minutes
+- The metadata-before-ingest fix (#92) prevents the worst case: a partial embedding failure no longer triggers infinite full re-ingest loops on every login attempt
+- Delta sync reduces the steady-state cost to near-zero (~5 events per login)
+
+### When this breaks
+
+- **10+ concurrent users** after Redis loss: 240K TPM is exhausted by user #2, cascading 429 retries for the rest
+- **100+ users**: recovery takes over an hour at default TPM, login experience is degraded for everyone
+- **Multi-replica deployments**: each replica independently triggers ingestion, multiplying TPM consumption
+
+### The upgrade path — Durable sync token storage
+
+Move sync tokens from Redis-only to a durable store so Redis loss doesn't trigger mass re-ingestion:
+
+**Option A: Metadata document in Azure AI Search**
+
+Store the sync token as a document in the search index itself (already durable, already available):
+
+```python
+# On sync completion
+await upsert_documents(user_id, [{
+    "id": f"sync_meta:{user_id}",
+    "user_id": user_id,
+    "source_type": "sync_metadata",
+    "content": "",
+    "embedding": [0.0] * 1536,  # zero vector (not searchable)
+    "sync_token": sync_token,
+    "last_modified": datetime.now(UTC).isoformat(),
+}])
+```
+
+Recovery flow: Redis miss → query search index for metadata doc → found → delta sync.
+
+**Option B: Recover from search index `last_modified`**
+
+If the user has documents in the index, use the most recent `last_modified` timestamp with Google Calendar's `updatedMin` parameter to fetch only changes since the last upsert and obtain a fresh sync token:
+
+```python
+# Redis miss, but user has indexed documents
+latest_doc = await search(user_id, query="*", order_by=["last_modified desc"], top=1)
+if latest_doc:
+    updated_min = latest_doc["last_modified"]  # minus safety margin
+    events, sync_token = await fetch_events(updatedMin=updated_min)
+    # Process only the delta, store fresh sync token
+```
+
+Caveats: `updatedMin` can't combine with `timeMin`/`timeMax`, so this returns changes across the entire calendar history. Also requires subtracting a safety margin since our `last_modified` is upsert time, not Google's modification time.
+
+**Option C: PostgreSQL (when added for other reasons)**
+
+If the architecture adds Postgres for user profiles or other durable state, sync tokens naturally belong there alongside other per-user metadata.
+
+### Scaling strategy summary
+
+| Scale | Strategy | Monthly cost | TPM needed |
+|-------|----------|--------------|------------|
+| 1-10 users | Current design (Redis-only sync tokens) | ~$0 | 240K (default) |
+| 10-100 users | Ingestion queue + sync token recovery from search index | $1-3 | 1M |
+| 100-1,000 users | Priority queue (delta before full ingest) + provisioned throughput | $3-30 | 10M+ |
+| 1,000+ users | Dedicated embedding deployment per region, async job queue, durable sync token store | $30+ | Multi-deployment |
+
+### Trigger to upgrade
+
+- Redis failover event causes visible re-ingest storm (mass `"Starting full ingest"` logs)
+- Scaling beyond 10 active users
+- Moving to multi-replica deployment where Redis persistence becomes critical


### PR DESCRIPTION
## Summary

- **Batching**: `process_events()` now chunks events into configurable batches (default 50) with inter-batch delay, keeping memory bounded and respecting Azure OpenAI TPM limits
- **Exponential backoff retry**: Retries on transient errors (`RateLimitError`, `APIConnectionError`, `APITimeoutError`, `InternalServerError`) with exponential backoff that respects the `Retry-After` header
- **Search retry**: `upsert_documents()` and `delete_documents()` now retry on transient Azure Search errors (429, 500, 503, network errors)
- **Structured logging**: Added progress logging at every pipeline stage — batch progress, partial failure warnings, ingestion start/complete, upsert/delete results
- **Content truncation**: `format_event_text()` caps output at configurable max length to prevent token limit blowouts from long event descriptions
- **CancelledError fix**: Background task now handles `asyncio.CancelledError` separately for graceful shutdown
- **Deferred decisions**: Documented distributed sync lock and proactive token budget tracking in `TRADEOFFS.md`

## Files Changed

| File | Change |
|------|--------|
| `backend/app/core/config.py` | 5 new embedding pipeline settings |
| `backend/app/search/embeddings.py` | Batch loop, `_embed_with_retry()`, `_parse_retry_after()`, text truncation |
| `backend/app/search/service.py` | Retry with backoff on upsert/delete, structured logging |
| `backend/app/context_ingestion/tasks.py` | `CancelledError` handling, completion logging |
| `backend/tests/test_embeddings.py` | 16 new tests (batching, retry, backoff, truncation) |
| `backend/tests/test_context_ingestion.py` | 1 new test (CancelledError propagation) |
| `backend/tests/test_search.py` | 3 new tests (search retry behavior) |
| `docs/TRADEOFFS.md` | 2 new sections (sync lock, token budget) |

## Test plan

- [x] All 273 tests pass (5 pre-existing guardrails failures unrelated)
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `mypy` clean (0 errors)
- [x] `pyright` clean on modified files (0 errors)
- [ ] Deploy to dev environment and trigger full ingest with 500+ events on 10K TPM quota
- [ ] Verify batch progress logs appear: `"Batch 3/12: embedded 50 events for user X"`
- [ ] Verify 429 retry logs appear when rate limited: `"RateLimitError (attempt 1/3), retrying in 30.0s"`

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch processing for embeddings with configurable batch size and inter-batch delay.
  * New embedding configuration options (batching, retries, delays, max text length).
  * App startup ensures search index exists before serving.

* **Bug Fixes**
  * Improved retry/backoff and error handling for embedding and search operations; clearer failure logging and resilience.
  * Ingestion now persists sync metadata before ingest and propagates cancellation properly.
  * Endpoint presence validated with explicit errors.

* **Documentation**
  * Added tradeoffs doc on ingestion sync and embedding token budgeting.

* **Style**
  * Minor docstring and formatting cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->