### PR TITLE
refactor(api): extract Google credential builder into shared module

### DIFF
--- a/backend/app/agents/router.py
+++ b/backend/app/agents/router.py
@@ -16,8 +16,8 @@ from starlette.requests import Request
 
 from app.agents.calendar_agent import build_thread_id, get_agent
 from app.agents.guardrails import check_canary_leak
-from app.agents.tools.calendar_tools import CALENDAR_EVENTS_SCOPE, SCOPE_ERROR_SENTINEL
 from app.auth.dependencies import get_current_user
+from app.auth.google_credentials import CALENDAR_EVENTS_SCOPE, SCOPE_ERROR_SENTINEL
 from app.core.config import settings
 from app.core.middleware import limiter
 from app.users.schemas import UserResponse

--- a/backend/app/agents/tools/calendar_tools.py
+++ b/backend/app/agents/tools/calendar_tools.py
@@ -9,208 +9,18 @@ import asyncio
 import json
 import logging
 import re
-import time
-from collections import OrderedDict
 from datetime import datetime
-from functools import partial
 from typing import Annotated, Any
 from zoneinfo import ZoneInfo
 
-import requests
-from google.oauth2.credentials import Credentials
-from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from langchain_core.tools import tool
 from langgraph.prebuilt import InjectedState
 from langgraph.types import interrupt
 
-from app.auth.token_storage import (
-    StoredToken,
-    TokenEncryptionError,
-    TokenNotFoundError,
-    get_token,
-    store_token,
-)
-from app.core.config import settings
+from app.auth.google_credentials import SCOPE_ERROR_SENTINEL, build_calendar_service
 
 logger = logging.getLogger(__name__)
-
-GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
-CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
-CALENDAR_READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
-CALENDAR_SCOPES = frozenset({CALENDAR_EVENTS_SCOPE, CALENDAR_READONLY_SCOPE})
-SCOPE_ERROR_SENTINEL = "##SCOPE_REQUIRED##calendar"
-_GOOGLE_TIMEOUT = 10
-
-# Per-user lock to prevent concurrent token refreshes (single-instance only;
-# multi-instance deployments would need a Redis-based distributed lock).
-# NOTE: If a lock is evicted while held (extremely unlikely at maxsize 1024),
-# a concurrent refresh for the same user may run in parallel — harmless since
-# the refresh operation is idempotent.
-_REFRESH_LOCK_MAXSIZE = 1024
-_refresh_locks: OrderedDict[str, asyncio.Lock] = OrderedDict()
-
-
-def _get_refresh_lock(user_id: str) -> asyncio.Lock:
-    """Return a per-user refresh lock, creating if needed. Bounded by LRU eviction."""
-    if user_id in _refresh_locks:
-        _refresh_locks.move_to_end(user_id)
-        return _refresh_locks[user_id]
-    if len(_refresh_locks) >= _REFRESH_LOCK_MAXSIZE:
-        _refresh_locks.popitem(last=False)
-    lock = asyncio.Lock()
-    _refresh_locks[user_id] = lock
-    return lock
-
-
-# ---------------------------------------------------------------------------
-# Credential helpers
-# ---------------------------------------------------------------------------
-
-
-async def _refresh_token_for_tool(
-    user_id: str, stored: StoredToken
-) -> StoredToken | str:
-    """Refresh an expired Google OAuth token.
-
-    Returns updated StoredToken on success, or an error message string on failure.
-    Does NOT raise HTTPException — tools must return error strings.
-    """
-    loop = asyncio.get_running_loop()
-    try:
-        response = await loop.run_in_executor(
-            None,
-            partial(
-                requests.post,
-                GOOGLE_TOKEN_URL,
-                data={
-                    "client_id": settings.google_client_id,
-                    "client_secret": settings.google_client_secret,
-                    "grant_type": "refresh_token",
-                    "refresh_token": stored.refresh_token,
-                },
-                timeout=_GOOGLE_TIMEOUT,
-            ),
-        )
-    except requests.RequestException as e:
-        logger.warning("Token refresh network error for user %s: %s", user_id, e)
-        return "Google token refresh failed — network error."
-
-    if not response.ok:
-        logger.warning(
-            "Token refresh failed for user %s: %s %s",
-            user_id,
-            response.status_code,
-            response.text[:200],
-        )
-        return "Google token refresh failed — please re-authenticate."
-
-    try:
-        data = response.json()
-    except ValueError:
-        return "Google token refresh returned invalid response."
-
-    new_access_token = data.get("access_token")
-    expires_in = data.get("expires_in")
-    if not isinstance(new_access_token, str) or not isinstance(expires_in, int):
-        return "Google token refresh returned unexpected data."
-
-    new_expires_at = int(time.time()) + expires_in
-    new_refresh_token = data.get("refresh_token")
-
-    # Use scopes from Google's response when available (self-correcting);
-    # fall back to stored scopes if Google omits the field.
-    scope_str = data.get("scope")
-    refreshed_scopes = (
-        scope_str.split() if isinstance(scope_str, str) and scope_str else stored.scopes
-    )
-
-    updated = StoredToken(
-        access_token=new_access_token,
-        refresh_token=(
-            new_refresh_token
-            if isinstance(new_refresh_token, str)
-            else stored.refresh_token
-        ),
-        expires_at=new_expires_at,
-        scopes=refreshed_scopes,
-    )
-
-    try:
-        await store_token(user_id, updated)
-    except TokenEncryptionError:
-        logger.exception("Token encryption failed during refresh for user %s", user_id)
-        return "Failed to store refreshed token."
-
-    return updated
-
-
-async def _get_credentials(user_id: str) -> Credentials | str:
-    """Retrieve user's Google OAuth credentials, refreshing if expired.
-
-    Returns google.oauth2.credentials.Credentials on success,
-    or an error message string on failure.
-    """
-    try:
-        stored = await get_token(user_id)
-    except TokenNotFoundError:
-        return "No Google token found — please sign in and grant calendar access."
-    except TokenEncryptionError:
-        return "Failed to retrieve Google token — please re-authenticate."
-
-    # Refresh if expired (with 60s buffer), using a per-user lock
-    # to prevent concurrent refreshes from racing on the same token
-    if stored.expires_at < int(time.time()) + 60:
-        async with _get_refresh_lock(user_id):
-            # Re-check after acquiring lock — another coroutine may have refreshed
-            try:
-                stored = await get_token(user_id)
-            except (TokenNotFoundError, TokenEncryptionError):
-                return "Token became unavailable during refresh."
-            if stored.expires_at < int(time.time()) + 60:
-                result = await _refresh_token_for_tool(user_id, stored)
-                if isinstance(result, str):
-                    return result
-                stored = result
-
-    return Credentials(  # type: ignore[no-untyped-call]
-        token=stored.access_token,
-        refresh_token=stored.refresh_token,
-        token_uri=GOOGLE_TOKEN_URL,
-        client_id=settings.google_client_id,
-        client_secret=settings.google_client_secret,
-    )
-
-
-async def _build_service(user_id: str) -> Any | str:
-    """Build a Google Calendar API Resource for the given user.
-
-    Pre-checks that the stored token includes calendar scopes before
-    attempting the Google API call. Returns the Resource on success,
-    or an error message string on failure.
-    """
-    # Pre-check: verify calendar scope before making a doomed API call
-    try:
-        stored = await get_token(user_id)
-        if CALENDAR_EVENTS_SCOPE not in stored.scopes:
-            logger.warning(
-                "User %s missing calendar scope. Stored scopes: %s",
-                user_id,
-                stored.scopes,
-            )
-            return SCOPE_ERROR_SENTINEL
-    except (TokenNotFoundError, TokenEncryptionError):
-        pass  # _get_credentials will handle with a proper error message
-
-    creds = await _get_credentials(user_id)
-    if isinstance(creds, str):
-        return creds
-
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(
-        None,
-        partial(build, "calendar", "v3", credentials=creds),
-    )
 
 
 def _is_insufficient_permissions(e: HttpError) -> bool:
@@ -228,7 +38,7 @@ async def get_current_datetime(
     user_id: Annotated[str, InjectedState("user_id")],
 ) -> str:
     """Get the current date/time in the user's primary calendar timezone."""
-    service = await _build_service(user_id)
+    service = await build_calendar_service(user_id)
     if isinstance(service, str):
         return service
 
@@ -256,7 +66,7 @@ async def get_calendars_info(
     user_id: Annotated[str, InjectedState("user_id")],
 ) -> str:
     """Get the user's Google Calendars as JSON. Call this before search_events."""
-    service = await _build_service(user_id)
+    service = await build_calendar_service(user_id)
     if isinstance(service, str):
         return service
 
@@ -302,7 +112,7 @@ async def search_events(
         max_results: Maximum number of events to return per calendar (default 10).
         query: Optional text to filter events by (matches summary, description, etc.).
     """
-    service = await _build_service(user_id)
+    service = await build_calendar_service(user_id)
     if isinstance(service, str):
         return service
 
@@ -430,7 +240,7 @@ async def create_event(
     }
     interrupt(event_details)
 
-    service = await _build_service(user_id)
+    service = await build_calendar_service(user_id)
     if isinstance(service, str):
         return service
 
@@ -525,7 +335,7 @@ async def update_event(
     }
     interrupt(event_details)
 
-    service = await _build_service(user_id)
+    service = await build_calendar_service(user_id)
     if isinstance(service, str):
         return service
 
@@ -608,7 +418,7 @@ async def delete_event(
     }
     interrupt(event_details)
 
-    service = await _build_service(user_id)
+    service = await build_calendar_service(user_id)
     if isinstance(service, str):
         return service
 

--- a/backend/app/auth/google_credentials.py
+++ b/backend/app/auth/google_credentials.py
@@ -1,0 +1,200 @@
+"""Shared Google OAuth credential and Calendar service builder.
+
+Provides public APIs for resolving per-user Google OAuth credentials from
+Redis and constructing authenticated Google Calendar API service objects.
+Used by both the LangGraph agent tools and the context ingestion pipeline.
+"""
+
+import asyncio
+import logging
+import time
+from collections import OrderedDict
+from functools import partial
+from typing import Any
+
+import requests
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+from app.auth.token_storage import (
+    StoredToken,
+    TokenEncryptionError,
+    TokenNotFoundError,
+    get_token,
+    store_token,
+)
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
+CALENDAR_READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
+CALENDAR_SCOPES = frozenset({CALENDAR_EVENTS_SCOPE, CALENDAR_READONLY_SCOPE})
+SCOPE_ERROR_SENTINEL = "##SCOPE_REQUIRED##calendar"
+_GOOGLE_TIMEOUT = 10
+
+# Per-user lock to prevent concurrent token refreshes (single-instance only;
+# multi-instance deployments would need a Redis-based distributed lock).
+# NOTE: If a lock is evicted while held (extremely unlikely at maxsize 1024),
+# a concurrent refresh for the same user may run in parallel — harmless since
+# the refresh operation is idempotent.
+_REFRESH_LOCK_MAXSIZE = 1024
+_refresh_locks: OrderedDict[str, asyncio.Lock] = OrderedDict()
+
+
+def _get_refresh_lock(user_id: str) -> asyncio.Lock:
+    """Return a per-user refresh lock, creating if needed. Bounded by LRU eviction."""
+    if user_id in _refresh_locks:
+        _refresh_locks.move_to_end(user_id)
+        return _refresh_locks[user_id]
+    if len(_refresh_locks) >= _REFRESH_LOCK_MAXSIZE:
+        _refresh_locks.popitem(last=False)
+    lock = asyncio.Lock()
+    _refresh_locks[user_id] = lock
+    return lock
+
+
+async def _refresh_token_for_tool(
+    user_id: str, stored: StoredToken
+) -> StoredToken | str:
+    """Refresh an expired Google OAuth token.
+
+    Returns updated StoredToken on success, or an error message string on failure.
+    Does NOT raise HTTPException — tools must return error strings.
+    """
+    loop = asyncio.get_running_loop()
+    try:
+        response = await loop.run_in_executor(
+            None,
+            partial(
+                requests.post,
+                GOOGLE_TOKEN_URL,
+                data={
+                    "client_id": settings.google_client_id,
+                    "client_secret": settings.google_client_secret,
+                    "grant_type": "refresh_token",
+                    "refresh_token": stored.refresh_token,
+                },
+                timeout=_GOOGLE_TIMEOUT,
+            ),
+        )
+    except requests.RequestException as e:
+        logger.warning("Token refresh network error for user %s: %s", user_id, e)
+        return "Google token refresh failed — network error."
+
+    if not response.ok:
+        logger.warning(
+            "Token refresh failed for user %s: %s %s",
+            user_id,
+            response.status_code,
+            response.text[:200],
+        )
+        return "Google token refresh failed — please re-authenticate."
+
+    try:
+        data = response.json()
+    except ValueError:
+        return "Google token refresh returned invalid response."
+
+    new_access_token = data.get("access_token")
+    expires_in = data.get("expires_in")
+    if not isinstance(new_access_token, str) or not isinstance(expires_in, int):
+        return "Google token refresh returned unexpected data."
+
+    new_expires_at = int(time.time()) + expires_in
+    new_refresh_token = data.get("refresh_token")
+
+    # Use scopes from Google's response when available (self-correcting);
+    # fall back to stored scopes if Google omits the field.
+    scope_str = data.get("scope")
+    refreshed_scopes = (
+        scope_str.split() if isinstance(scope_str, str) and scope_str else stored.scopes
+    )
+
+    updated = StoredToken(
+        access_token=new_access_token,
+        refresh_token=(
+            new_refresh_token
+            if isinstance(new_refresh_token, str)
+            else stored.refresh_token
+        ),
+        expires_at=new_expires_at,
+        scopes=refreshed_scopes,
+    )
+
+    try:
+        await store_token(user_id, updated)
+    except TokenEncryptionError:
+        logger.exception("Token encryption failed during refresh for user %s", user_id)
+        return "Failed to store refreshed token."
+
+    return updated
+
+
+async def get_google_credentials(user_id: str) -> Credentials | str:
+    """Retrieve user's Google OAuth credentials, refreshing if expired.
+
+    Returns google.oauth2.credentials.Credentials on success,
+    or an error message string on failure.
+    """
+    try:
+        stored = await get_token(user_id)
+    except TokenNotFoundError:
+        return "No Google token found — please sign in and grant calendar access."
+    except TokenEncryptionError:
+        return "Failed to retrieve Google token — please re-authenticate."
+
+    # Refresh if expired (with 60s buffer), using a per-user lock
+    # to prevent concurrent refreshes from racing on the same token
+    if stored.expires_at < int(time.time()) + 60:
+        async with _get_refresh_lock(user_id):
+            # Re-check after acquiring lock — another coroutine may have refreshed
+            try:
+                stored = await get_token(user_id)
+            except (TokenNotFoundError, TokenEncryptionError):
+                return "Token became unavailable during refresh."
+            if stored.expires_at < int(time.time()) + 60:
+                result = await _refresh_token_for_tool(user_id, stored)
+                if isinstance(result, str):
+                    return result
+                stored = result
+
+    return Credentials(  # type: ignore[no-untyped-call]
+        token=stored.access_token,
+        refresh_token=stored.refresh_token,
+        token_uri=GOOGLE_TOKEN_URL,
+        client_id=settings.google_client_id,
+        client_secret=settings.google_client_secret,
+    )
+
+
+async def build_calendar_service(user_id: str) -> Any | str:
+    """Build a Google Calendar API Resource for the given user.
+
+    Pre-checks that the stored token includes calendar scopes before
+    attempting the Google API call. Returns the Resource on success,
+    or an error message string on failure.
+    """
+    # Pre-check: verify calendar scope before making a doomed API call
+    try:
+        stored = await get_token(user_id)
+        if CALENDAR_EVENTS_SCOPE not in stored.scopes:
+            logger.warning(
+                "User %s missing calendar scope. Stored scopes: %s",
+                user_id,
+                stored.scopes,
+            )
+            return SCOPE_ERROR_SENTINEL
+    except (TokenNotFoundError, TokenEncryptionError):
+        pass  # get_google_credentials will handle with a proper error message
+
+    creds = await get_google_credentials(user_id)
+    if isinstance(creds, str):
+        return creds
+
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        None,
+        partial(build, "calendar", "v3", credentials=creds),
+    )

--- a/backend/app/context_ingestion/sync.py
+++ b/backend/app/context_ingestion/sync.py
@@ -75,14 +75,12 @@ async def store_sync_metadata(user_id: str, metadata: SyncMetadata) -> None:
 async def _get_calendar_service(user_id: str) -> Any:
     """Build a Google Calendar API service for the given user.
 
-    Reuses credential handling from calendar_tools to avoid duplicating
-    token refresh logic. Raises RuntimeError on failure.
+    Reuses credential handling from the shared google_credentials module
+    to avoid duplicating token refresh logic. Raises RuntimeError on failure.
     """
-    from app.agents.tools.calendar_tools import (
-        _build_service,  # pyright: ignore[reportPrivateUsage]
-    )
+    from app.auth.google_credentials import build_calendar_service
 
-    service = await _build_service(user_id)
+    service = await build_calendar_service(user_id)
     if isinstance(service, str):
         raise RuntimeError(service)
     return service

--- a/backend/tests/test_agent.py
+++ b/backend/tests/test_agent.py
@@ -28,8 +28,8 @@ from app.agents.prompts import (
     get_system_instructions,
 )
 from app.agents.state import AgentState
-from app.agents.tools.calendar_tools import CALENDAR_EVENTS_SCOPE, SCOPE_ERROR_SENTINEL
 from app.auth.dependencies import get_current_user
+from app.auth.google_credentials import CALENDAR_EVENTS_SCOPE, SCOPE_ERROR_SENTINEL
 from app.main import app
 from app.users.schemas import UserResponse
 from tests.conftest import TEST_USER_ID

--- a/backend/tests/test_calendar_tools.py
+++ b/backend/tests/test_calendar_tools.py
@@ -8,12 +8,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.agents.tools.calendar_tools import (
-    CALENDAR_EVENTS_SCOPE,
-    CALENDAR_READONLY_SCOPE,
-    SCOPE_ERROR_SENTINEL,
-    _build_service,  # pyright: ignore[reportPrivateUsage]
-    _get_credentials,  # pyright: ignore[reportPrivateUsage]
-    _refresh_token_for_tool,  # pyright: ignore[reportPrivateUsage]
     calendar_tools,
     create_event,
     delete_event,
@@ -21,6 +15,14 @@ from app.agents.tools.calendar_tools import (
     get_current_datetime,
     search_events,
     update_event,
+)
+from app.auth.google_credentials import (
+    CALENDAR_EVENTS_SCOPE,
+    CALENDAR_READONLY_SCOPE,
+    SCOPE_ERROR_SENTINEL,
+    _refresh_token_for_tool,  # pyright: ignore[reportPrivateUsage]
+    build_calendar_service,
+    get_google_credentials,
 )
 from app.auth.token_storage import StoredToken, TokenEncryptionError, TokenNotFoundError
 
@@ -53,7 +55,7 @@ def _mock_calendar_service() -> MagicMock:
 def _patch_settings(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
     """Ensure Google OAuth settings are available for all tests."""
     monkeypatch.setattr(
-        "app.agents.tools.calendar_tools.settings",
+        "app.auth.google_credentials.settings",
         MagicMock(
             google_client_id="test-client-id",
             google_client_secret="test-client-secret",
@@ -70,31 +72,31 @@ class TestGetCredentials:
     async def test_should_return_credentials_with_valid_token(self) -> None:
         token = _make_stored_token()
         with patch(
-            "app.agents.tools.calendar_tools.get_token",
+            "app.auth.google_credentials.get_token",
             new_callable=AsyncMock,
             return_value=token,
         ):
-            result = await _get_credentials(FAKE_USER_ID)
+            result = await get_google_credentials(FAKE_USER_ID)
             assert not isinstance(result, str)
             assert result.token == "valid-access-token"
 
     async def test_should_return_error_when_no_token_found(self) -> None:
         with patch(
-            "app.agents.tools.calendar_tools.get_token",
+            "app.auth.google_credentials.get_token",
             new_callable=AsyncMock,
             side_effect=TokenNotFoundError("No token"),
         ):
-            result = await _get_credentials(FAKE_USER_ID)
+            result = await get_google_credentials(FAKE_USER_ID)
             assert isinstance(result, str)
             assert "sign in" in result.lower()
 
     async def test_should_return_error_when_decryption_fails(self) -> None:
         with patch(
-            "app.agents.tools.calendar_tools.get_token",
+            "app.auth.google_credentials.get_token",
             new_callable=AsyncMock,
             side_effect=TokenEncryptionError("Bad key"),
         ):
-            result = await _get_credentials(FAKE_USER_ID)
+            result = await get_google_credentials(FAKE_USER_ID)
             assert isinstance(result, str)
             assert "re-authenticate" in result.lower()
 
@@ -104,17 +106,17 @@ class TestGetCredentials:
 
         with (
             patch(
-                "app.agents.tools.calendar_tools.get_token",
+                "app.auth.google_credentials.get_token",
                 new_callable=AsyncMock,
                 return_value=expired_token,
             ),
             patch(
-                "app.agents.tools.calendar_tools._refresh_token_for_tool",
+                "app.auth.google_credentials._refresh_token_for_tool",
                 new_callable=AsyncMock,
                 return_value=refreshed_token,
             ),
         ):
-            result = await _get_credentials(FAKE_USER_ID)
+            result = await get_google_credentials(FAKE_USER_ID)
             assert not isinstance(result, str)
             assert result.token == "refreshed-access-token"
 
@@ -126,11 +128,11 @@ class TestGetCredentials:
 
         # First call returns expired, second call (inside lock) returns fresh
         with patch(
-            "app.agents.tools.calendar_tools.get_token",
+            "app.auth.google_credentials.get_token",
             new_callable=AsyncMock,
             side_effect=[expired_token, fresh_token],
         ):
-            result = await _get_credentials(FAKE_USER_ID)
+            result = await get_google_credentials(FAKE_USER_ID)
             assert not isinstance(result, str)
             assert result.token == "already-refreshed"
 
@@ -139,17 +141,17 @@ class TestGetCredentials:
 
         with (
             patch(
-                "app.agents.tools.calendar_tools.get_token",
+                "app.auth.google_credentials.get_token",
                 new_callable=AsyncMock,
                 return_value=expired_token,
             ),
             patch(
-                "app.agents.tools.calendar_tools._refresh_token_for_tool",
+                "app.auth.google_credentials._refresh_token_for_tool",
                 new_callable=AsyncMock,
                 return_value="Google token refresh failed — please re-authenticate.",
             ),
         ):
-            result = await _get_credentials(FAKE_USER_ID)
+            result = await get_google_credentials(FAKE_USER_ID)
             assert isinstance(result, str)
             assert "re-authenticate" in result.lower()
 
@@ -166,11 +168,11 @@ class TestRefreshTokenForTool:
 
         with (
             patch(
-                "app.agents.tools.calendar_tools.requests.post",
+                "app.auth.google_credentials.requests.post",
                 return_value=mock_response,
             ),
             patch(
-                "app.agents.tools.calendar_tools.store_token",
+                "app.auth.google_credentials.store_token",
                 new_callable=AsyncMock,
             ) as mock_store,
         ):
@@ -185,7 +187,7 @@ class TestRefreshTokenForTool:
         import requests as req
 
         with patch(
-            "app.agents.tools.calendar_tools.requests.post",
+            "app.auth.google_credentials.requests.post",
             side_effect=req.RequestException("Connection error"),
         ):
             result = await _refresh_token_for_tool(FAKE_USER_ID, stored)
@@ -208,11 +210,11 @@ class TestRefreshTokenForTool:
 
         with (
             patch(
-                "app.agents.tools.calendar_tools.requests.post",
+                "app.auth.google_credentials.requests.post",
                 return_value=mock_response,
             ),
             patch(
-                "app.agents.tools.calendar_tools.store_token",
+                "app.auth.google_credentials.store_token",
                 new_callable=AsyncMock,
             ) as mock_store,
         ):
@@ -239,11 +241,11 @@ class TestRefreshTokenForTool:
 
         with (
             patch(
-                "app.agents.tools.calendar_tools.requests.post",
+                "app.auth.google_credentials.requests.post",
                 return_value=mock_response,
             ),
             patch(
-                "app.agents.tools.calendar_tools.store_token",
+                "app.auth.google_credentials.store_token",
                 new_callable=AsyncMock,
             ),
         ):
@@ -259,7 +261,7 @@ class TestRefreshTokenForTool:
         mock_response.text = "invalid_grant"
 
         with patch(
-            "app.agents.tools.calendar_tools.requests.post",
+            "app.auth.google_credentials.requests.post",
             return_value=mock_response,
         ):
             result = await _refresh_token_for_tool(FAKE_USER_ID, stored)
@@ -272,26 +274,26 @@ class TestBuildService:
         token = _make_stored_token()
         with (
             patch(
-                "app.agents.tools.calendar_tools.get_token",
+                "app.auth.google_credentials.get_token",
                 new_callable=AsyncMock,
                 return_value=token,
             ),
             patch(
-                "app.agents.tools.calendar_tools.build",
+                "app.auth.google_credentials.build",
                 return_value=MagicMock(),
             ) as mock_build,
         ):
-            result = await _build_service(FAKE_USER_ID)
+            result = await build_calendar_service(FAKE_USER_ID)
             assert not isinstance(result, str)
             mock_build.assert_called_once()
 
     async def test_should_return_error_when_credentials_fail(self) -> None:
         with patch(
-            "app.agents.tools.calendar_tools.get_token",
+            "app.auth.google_credentials.get_token",
             new_callable=AsyncMock,
             side_effect=TokenNotFoundError("No token"),
         ):
-            result = await _build_service(FAKE_USER_ID)
+            result = await build_calendar_service(FAKE_USER_ID)
             assert isinstance(result, str)
 
     async def test_should_return_scope_sentinel_when_calendar_scope_missing(
@@ -304,27 +306,27 @@ class TestBuildService:
             scopes=["openid", "email", "profile"],
         )
         with patch(
-            "app.agents.tools.calendar_tools.get_token",
+            "app.auth.google_credentials.get_token",
             new_callable=AsyncMock,
             return_value=identity_only_token,
         ):
-            result = await _build_service(FAKE_USER_ID)
+            result = await build_calendar_service(FAKE_USER_ID)
             assert result == SCOPE_ERROR_SENTINEL
 
     async def test_should_proceed_when_calendar_scope_present(self) -> None:
         token = _make_stored_token()  # includes calendar.events scope
         with (
             patch(
-                "app.agents.tools.calendar_tools.get_token",
+                "app.auth.google_credentials.get_token",
                 new_callable=AsyncMock,
                 return_value=token,
             ),
             patch(
-                "app.agents.tools.calendar_tools.build",
+                "app.auth.google_credentials.build",
                 return_value=MagicMock(),
             ),
         ):
-            result = await _build_service(FAKE_USER_ID)
+            result = await build_calendar_service(FAKE_USER_ID)
             assert not isinstance(result, str)
 
 
@@ -348,7 +350,7 @@ class TestHttpErrorDetection:
         service.calendars.return_value.get.return_value.execute.side_effect = error
 
         with patch(
-            "app.agents.tools.calendar_tools._build_service",
+            "app.agents.tools.calendar_tools.build_calendar_service",
             new_callable=AsyncMock,
             return_value=service,
         ):
@@ -361,7 +363,7 @@ class TestHttpErrorDetection:
         service.calendars.return_value.get.return_value.execute.side_effect = error
 
         with patch(
-            "app.agents.tools.calendar_tools._build_service",
+            "app.agents.tools.calendar_tools.build_calendar_service",
             new_callable=AsyncMock,
             return_value=service,
         ):
@@ -379,7 +381,7 @@ class TestHttpErrorDetection:
 def _patch_service(mock_service: MagicMock) -> Any:
     """Patch _build_service to return a mock."""
     return patch(
-        "app.agents.tools.calendar_tools._build_service",
+        "app.agents.tools.calendar_tools.build_calendar_service",
         new_callable=AsyncMock,
         return_value=mock_service,
     )
@@ -411,7 +413,7 @@ class TestGetCurrentDatetime:
 
     async def test_should_return_error_when_no_credentials(self) -> None:
         with patch(
-            "app.agents.tools.calendar_tools._build_service",
+            "app.agents.tools.calendar_tools.build_calendar_service",
             new_callable=AsyncMock,
             return_value="No Google token found — please sign in.",
         ):
@@ -802,14 +804,14 @@ class TestGetLlm:
 class TestRefreshLockBounding:
     @pytest.fixture(autouse=True)
     def _clear_locks(self) -> None:  # pyright: ignore[reportUnusedFunction]
-        from app.agents.tools.calendar_tools import (
+        from app.auth.google_credentials import (
             _refresh_locks,  # pyright: ignore[reportPrivateUsage]
         )
 
         _refresh_locks.clear()
 
     def test_returns_same_lock_for_same_user(self) -> None:
-        from app.agents.tools.calendar_tools import (
+        from app.auth.google_credentials import (
             _get_refresh_lock,  # pyright: ignore[reportPrivateUsage]
         )
 
@@ -818,7 +820,7 @@ class TestRefreshLockBounding:
         assert lock1 is lock2
 
     def test_bounded_to_maxsize(self) -> None:
-        from app.agents.tools.calendar_tools import (
+        from app.auth.google_credentials import (
             _REFRESH_LOCK_MAXSIZE,  # pyright: ignore[reportPrivateUsage]
             _get_refresh_lock,  # pyright: ignore[reportPrivateUsage]
             _refresh_locks,  # pyright: ignore[reportPrivateUsage]
@@ -829,7 +831,7 @@ class TestRefreshLockBounding:
         assert len(_refresh_locks) == _REFRESH_LOCK_MAXSIZE
 
     def test_evicts_oldest_entry(self) -> None:
-        from app.agents.tools.calendar_tools import (
+        from app.auth.google_credentials import (
             _REFRESH_LOCK_MAXSIZE,  # pyright: ignore[reportPrivateUsage]
             _get_refresh_lock,  # pyright: ignore[reportPrivateUsage]
             _refresh_locks,  # pyright: ignore[reportPrivateUsage]
@@ -841,7 +843,7 @@ class TestRefreshLockBounding:
         assert "oldest-user" not in _refresh_locks
 
     def test_lru_access_prevents_eviction(self) -> None:
-        from app.agents.tools.calendar_tools import (
+        from app.auth.google_credentials import (
             _REFRESH_LOCK_MAXSIZE,  # pyright: ignore[reportPrivateUsage]
             _get_refresh_lock,  # pyright: ignore[reportPrivateUsage]
             _refresh_locks,  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
## Summary

- Extract `_build_service` and `_get_credentials` from `calendar_tools.py` into a new shared module `app/auth/google_credentials.py` as public `build_calendar_service()` and `get_google_credentials()`
- Update all consumers (`calendar_tools.py`, `sync.py`, `router.py`) to import from the shared module
- Remove `pyright: ignore[reportPrivateUsage]` suppression from `sync.py` — the whole reason for this refactor

Closes #103

## Test plan

- [x] `uv run pytest` — 367 tests pass (0 failures)
- [x] `uv run mypy .` — 0 errors
- [x] `uv run pyright` — 0 new errors (9 pre-existing, unrelated)
- [x] `uv run ruff check .` — all checks passed
- [x] Verify no `_build_service` / `_get_credentials` references remain in `app/`
- [x] Verify no `pyright: ignore[reportPrivateUsage]` remains in `app/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated Google OAuth credential handling and Calendar API service management into a centralized module for more reliable token lifecycle and improved system consistency across calendar operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->