### PR TITLE
fix(infra): fix OAuth redirect, backend proxy, and zero-replica scaling

### DIFF
--- a/infra/modules/container-apps/main.tf
+++ b/infra/modules/container-apps/main.tf
@@ -181,11 +181,16 @@ resource "azurerm_container_app" "frontend" {
         value = "true"
       }
 
-      # Server-side proxy reads this at runtime to forward API calls to the
-      # internal backend. Client-side code uses relative URLs via api.ts and
-      # proxy.ts — the browser never contacts the backend directly.
       env {
-        name  = "NEXT_PUBLIC_API_URL"
+        name  = "AUTH_URL"
+        value = "https://${local.frontend_fqdn}"
+      }
+
+      # Server-side proxy reads INTERNAL_API_URL at runtime to forward API
+      # calls to the internal backend. NEXT_PUBLIC_API_URL is baked into the
+      # client bundle at build time and ignored by server code at runtime.
+      env {
+        name  = "INTERNAL_API_URL"
         value = "https://${local.backend_fqdn}"
       }
 

--- a/infra/modules/container-apps/variables.tf
+++ b/infra/modules/container-apps/variables.tf
@@ -167,7 +167,7 @@ variable "backend_memory" {
 variable "frontend_min_replicas" {
   description = "Minimum number of frontend container replicas"
   type        = number
-  default     = 0
+  default     = 1
 }
 
 variable "frontend_max_replicas" {
@@ -179,7 +179,7 @@ variable "frontend_max_replicas" {
 variable "backend_min_replicas" {
   description = "Minimum number of backend container replicas"
   type        = number
-  default     = 0
+  default     = 1
 }
 
 variable "backend_max_replicas" {


### PR DESCRIPTION
## Summary

- **OAuth redirect to 0.0.0.0:3000**: Added `AUTH_URL` env var to the frontend container, pointing to the production FQDN. Auth.js was falling back to the Dockerfile's `HOSTNAME=0.0.0.0` instead of deriving the URL from request headers.

- **502 / network errors on chat and settings**: Replaced `NEXT_PUBLIC_API_URL` with `INTERNAL_API_URL` in Terraform. `NEXT_PUBLIC_*` vars are inlined at build time by Next.js (baked in as `http://localhost:8000`), so the runtime Terraform value was never seen. `INTERNAL_API_URL` is a plain env var read at runtime by the server-side fallback chain in `api.ts`, `route.ts`, and `token-sync.ts`.

- **KEDA scaling to zero**: Changed `frontend_min_replicas` and `backend_min_replicas` defaults from `0` to `1`.

## Test plan

- [ ] `terraform plan` shows expected env var changes and replica updates
- [ ] `terraform apply` deploys successfully
- [ ] Google OAuth sign-in redirects back to the production URL (not 0.0.0.0)
- [ ] Chat messages stream without 502 errors
- [ ] Settings timezone save succeeds
- [ ] Token sync logs show successful backend connection
- [ ] Containers stay at 1 replica and don't scale to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container deployment configuration to improve service routing between frontend and backend components.
  * Increased default minimum deployment instances for both frontend and backend services to ensure consistent availability without cold-start delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->