### PR TITLE
feat(#133): backend-rules-rewrite

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -1,104 +1,78 @@
 ---
-description: FastAPI + Python 3.12 + Pydantic v2 + LangGraph conventions
+description: FastAPI + Python 3.12 + Pydantic v2 backend conventions
 paths:
   - "backend/**"
 ---
 
-# Backend Rules (FastAPI + LangGraph)
+# Backend Rules
 
-## FastAPI Patterns
+## Architecture
 
-### Endpoints
-- Use `async def` for all endpoints with I/O (Redis, HTTP, database)
-- Never call blocking code inside `async def` — use `run_in_executor` if unavoidable
-- Keep routes thin: validate input, call service, return response — business logic in `service.py`
-- Use `Depends()` for dependency injection — chain small, focused dependencies
-- Set `response_model=XResponse` on route decorators for automatic serialization
+- Thin routes, thick services: routes validate input and return responses — business logic lives in `service.py` modules
+- Service layers raise domain exceptions (e.g., `TokenNotFoundError`) — never import `HTTPException` outside of route/dependency files
+- Domain exceptions should carry `status_code: int` and `error_code: str` attributes for consistent HTTP mapping and machine-readable client responses
+- All shared resources use the singleton getter pattern (`get_*()` / `close_*()`) — init eagerly in lifespan startup, clean up in shutdown with isolated `try/except` per resource
+- One `Settings(BaseSettings)` instance in `core/config.py` — import it, never re-instantiate
+- `Depends()` for dependency injection — `# noqa: B008` on default args (Ruff false positive)
+- One-line docstring on every endpoint — it appears in auto-generated OpenAPI docs
 
-### Request/Response Models
-- Separate models for request and response — never reuse one model for both
-- Create `CreateX`, `UpdateX`, `XResponse` schemas per domain
-- Set `Field(max_length=...)` on all string fields
-- Use `model_config = ConfigDict(from_attributes=True, extra="forbid", str_strip_whitespace=True)`
+## Error Handling
 
-### Exception Handling
-- Use `HTTPException` for standard HTTP errors
-- Register custom exception handlers via `@app.exception_handler`
-- Always include a catch-all handler that logs context but returns generic 500
-- In service layers, raise domain exceptions — let handlers translate to HTTP responses
+- Define a base `AppError(Exception)` in `core/exceptions.py` with `status_code`, `error_code`, and `message` — all domain exceptions inherit from it
+- Register ONE global `@app.exception_handler(AppError)` that returns structured JSON: `{"error_code": "TOKEN_NOT_FOUND", "message": "...", "request_id": "..."}`
+- Use `HTTPException` directly only in route/dependency files for auth failures (401/403) where there is no domain concept to model
+- Never let unhandled exceptions leak stack traces — catch-all handler logs full traceback, returns generic 500
 
-### Middleware
-- Middleware ordering is LIFO (last added = outermost)
-- Register in order: CORS -> Correlation ID -> Rate Limiting
-- Never use `allow_origins=["*"]` with `allow_credentials=True`
+## Async Patterns
 
-### Lifespan
-- Use `lifespan` async context manager (not deprecated `@app.on_event`)
-- Use module-level singletons with `get_*()` / `reset_*()` for shared resources — provides better testability without requiring an app instance
-- Always clean up resources in the shutdown phase
+- `run_in_executor` is an escape hatch for sync-only SDKs (Google OAuth, Calendar API) — prefer async-native libraries (httpx) for new code
+- Set explicit timeouts on EVERY external call: `httpx.Timeout(connect=5, read=30)`, `Redis.from_url(..., socket_timeout=5, socket_connect_timeout=5)`, `asyncio.wait_for()` around `run_in_executor` calls
+- Configure Redis for production: `retry_on_timeout=True`, `health_check_interval=30`, `socket_keepalive=True`
+- `asyncio.TaskGroup` over `asyncio.gather` — structured concurrency with automatic cancellation on failure
+- Scope `asyncio.Lock` per-user, not global — see the LRU-bounded lock pattern in `auth/google_credentials.py`
+- `BackgroundTasks` for fire-and-forget post-response work — avoid `asyncio.create_task()` in request handlers (event loop holds weak references, untracked tasks get GC'd)
+- All background task functions MUST catch and log all exceptions; re-raise `asyncio.CancelledError` after logging
 
 ## Pydantic v2
 
-- Use `field_validator(mode="before")` for pre-processing, `mode="after"` for business rules
-- Use `model_validator(mode="after")` for cross-field validation
-- Use discriminated unions with `Field(discriminator="type")` for polymorphic types
-- Use `model_dump(exclude_unset=True)` for PATCH operations
-- Use `@computed_field` on `@property` for derived values in API responses
+- Separate request and response models — never reuse one for both
+- Request models: `ConfigDict(extra="forbid", str_strip_whitespace=True)` — rejects unknown fields, strips whitespace
+- Response models: `ConfigDict(from_attributes=True, extra="forbid")`
+- `Field(max_length=...)` on all string fields; `Field(gt=0)` on numeric bounds
+- `model_dump(exclude_unset=True)` only for PATCH operations — never on response serialization
+- Use `TypeAdapter` to validate non-model types (lists, dicts) at system boundaries instead of `json.loads()` + manual key access
+- No docstrings on Pydantic models — field names, types, and `Field(description=...)` are the documentation
 
-## Docstrings
+## Logging
 
-- Use Google-style docstrings (compatible with `parse_docstring=True` and Sphinx)
-- One-line summary in imperative mood. Extended description only when the function does something non-obvious
-- `Args:` only when parameter names + types aren't self-explanatory. `Returns:` only when the return type annotation isn't sufficient. `Raises:` when callers need to handle domain exceptions
-- Pydantic models: do NOT add docstrings — field names, types, and `Field(description=...)` are the documentation. Only add a class-level docstring if the model's purpose isn't clear from its name
-- FastAPI endpoints: add a one-line docstring (it appears in the auto-generated OpenAPI/Swagger docs)
-- Test functions: do NOT add docstrings — the test name (`test_should_reject_expired_token`) is the documentation
-
-## Python Async
-
-- Use `asyncio.TaskGroup` (not `asyncio.gather`) for concurrent operations — structured concurrency
-- Every resource opened in startup MUST be closed in shutdown
-- Redis: `await redis.aclose()` explicitly — no async destructor magic
-- HTTP clients: one `httpx.AsyncClient` per app in lifespan, not per request
-- Use `async with` for transient connections
-- Never use `time.sleep()` in async code — use `await asyncio.sleep()`
-
-## LangGraph Agent
-
-### State
-- Use `TypedDict` with `Annotated` reducers — lighter than Pydantic for LangGraph
-- Keep state serializable — no complex objects, connections, or file handles
-
-### Tools
-- Use `@tool(parse_docstring=True)` — LLM uses docstrings to decide when to call tools
-- Full type hints on all tool parameters — these define the input schema
-- Tools should do ONE action — no Swiss-army-knife tools
-- Return error messages as strings, NEVER raise exceptions — raising stops the flow
-- Wrap every external API call in try/except
-- Use `InjectedState` to pass graph state without exposing it to the LLM
-
-### Human-in-the-Loop
-- Use `interrupt()` for write operations (create/update/delete events)
-- Requires checkpointer and `thread_id` in config
-- Emit structured SSE events before interrupting
+- Use `structlog` with stdlib integration via `ProcessorFormatter` — all logs (structlog + uvicorn + FastAPI) produce identical structured output
+- JSON output in production, `ConsoleRenderer` in development — controlled by one env var (`LOG_FORMAT=json|console`), configured once at startup
+- Bind request-scoped context via `structlog.contextvars`: `clear_contextvars()` in middleware, then `bind_contextvars(request_id=..., user_id=...)` — never pass these as positional format args
+- Use keyword arguments for structured data: `logger.info("ingest_complete", user_id=uid, event_count=n)` not `logger.info("Ingest complete for %s: %d", uid, n)`
+- Integrate with existing `asgi-correlation-id` middleware — read the `X-Request-ID` header and bind it, don't generate a separate ID
 
 ## Type Checking
 
-- `mypy --strict` and `pyright --strict` must both pass on the full backend project before considering work done
-- Never use `# type: ignore` without a specific error code (e.g. `# type: ignore[arg-type]`)
-- Never use `cast()` to paper over a real type error — fix the underlying issue
-- Use `TYPE_CHECKING` imports to avoid circular imports and runtime overhead
-- For third-party libraries without `py.typed`: add a per-module override in `[tool.mypy]`, never use blanket `ignore_missing_imports`
+- `mypy --strict` and `pyright` must both pass — no exceptions
+- Every `# type: ignore` MUST have a specific error code AND a comment explaining why: `# type: ignore[misc]  # redis-py returns Any for hgetall`
+- Enable `warn_unused_ignores = true` so stale ignores fail the build
+- Use `Protocol` for typing interfaces from untyped third-party libraries (e.g., Google Calendar service objects) — never leave them as `Any`
+- Use `ParamSpec` + `Concatenate` for decorators wrapping async functions — preserves the decorated function's signature
+- `TYPE_CHECKING` imports for cross-module type references — prevents circular imports and reduces startup time
+- Never use `cast()` to silence a real type error — only for narrowing from a library's `Any` when you are certain of the runtime type
 
-### Testing Agents
-- Use `GenericFakeChatModel` for deterministic LLM mocking
-- Unit test individual tools in isolation before testing the full graph
-- Test the full chain: LLM decision -> tool params -> execution -> result -> response
+## SSE Streaming
+
+- Async generator → `StreamingResponse(media_type="text/event-stream")` with JSON events using a `type` discriminator
+- Always emit a terminal event (`done` or `error`) — clients rely on these to close the connection
+- Wrap the entire generator body in `try/except` — catch `asyncio.CancelledError` BEFORE `Exception` (client disconnect is normal, log at info, don't yield further events)
+- Never let exceptions propagate raw out of the generator — yield a structured error event, then done, then return
 
 ## Testing
 
-- Set `asyncio_mode = "auto"` in `pyproject.toml` — eliminates `@pytest.mark.asyncio` boilerplate
-- Use `httpx.AsyncClient` with `ASGITransport(app=app)` for async endpoint tests
-- Use `app.dependency_overrides` for swapping dependencies — FastAPI's built-in mechanism
-- Mock: external APIs (Google, Azure). Test with real: Redis (use Docker), own endpoints
-- Test YOUR business logic, not framework behavior (don't test that Pydantic validates types)
+- `asyncio_mode = "auto"` — no `@pytest.mark.asyncio` decorator needed
+- `httpx.AsyncClient(transport=ASGITransport(app=app))` for endpoint tests
+- Always `app.dependency_overrides.clear()` in fixture teardown — prevents leakage between tests
+- `autouse` fixtures calling `reset_*()` for singleton isolation between tests
+- Mock external APIs (Google OAuth, cloud services); test own endpoints and business logic real
+- `monkeypatch` for settings; `unittest.mock.patch` + `AsyncMock` for function mocks

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -248,7 +248,7 @@ wheels = [
 
 [[package]]
 name = "calendar-agent-backend"
-version = "0.1.0"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "asgi-correlation-id" },

--- a/docs/RULES-GUIDE.md
+++ b/docs/RULES-GUIDE.md
@@ -1,0 +1,82 @@
+# Writing Rules Files
+
+Guide for writing `.claude/rules/` files. Apply when creating or rewriting any rules file (stories #134, #135, #136).
+
+## Philosophy
+
+Rules files are **lean, best-practice-oriented backbone guidance** — not codebase documentation. They steer the AI toward production-quality code for things it cannot infer from reading the codebase.
+
+If a current codebase pattern is wrong and you encode it as a rule, it gets amplified into every new file. Rules should be **forward-looking best practices**, not backward-looking pattern documentation.
+
+## Target Size
+
+- **60-80 lines, 3-5 KB** (~800-1200 tokens) for a path-scoped rules file
+- Reference: `code-quality.md` (60 lines), `tdd.md` (52 lines) — good models
+- Hard ceiling: ~130 lines (only justified for complex domains with skill orchestration, like `frontend.md`)
+
+## The Litmus Test
+
+Before including any rule, apply all three filters:
+
+1. **Would the AI get this wrong without this rule?** If existing code demonstrates the pattern clearly, the AI will follow it via in-context learning. Remove.
+2. **Is this discoverable by reading one file?** If yes, the AI can find it. Remove.
+3. **Is this already in another rules file?** If `code-quality.md` or `tdd.md` covers it, don't repeat. Remove.
+
+If a line fails any filter, it doesn't belong.
+
+## What to Include
+
+| Category | Example |
+|----------|---------|
+| **Architecture constraints** | "Service layers raise domain exceptions — never import HTTPException in service modules" |
+| **Best practices the codebase should adopt** | Structlog over stdlib, base exception classes, explicit timeouts |
+| **Non-obvious project-specific gotchas** | Which SDKs need `run_in_executor`, how locks are scoped |
+| **Conventions that differ from defaults** | `asyncio_mode = "auto"`, `extra="forbid"` on request models |
+| **Contracts the AI must preserve** | SSE event types, terminal event requirement |
+
+## What to Exclude
+
+| Category | Why |
+|----------|-----|
+| **Project layout trees** | Discoverable — the AI can `ls` or `Glob` |
+| **Tables documenting existing code** (singletons, fixtures, status codes) | Discoverable — the AI can grep for patterns |
+| **Code examples mirroring existing code** | The codebase IS the example — say "follow existing pattern" |
+| **Migration/transitional notes** | Project context, not coding rules — belongs in specs or PRD |
+| **Things the LLM already knows** | `asyncio.sleep` over `time.sleep`, HTTP status code meanings, standard Python conventions |
+| **Rules from other files** | `code-quality.md` covers security, cleanup, dependencies, performance — don't duplicate |
+| **Logging/naming conventions the LLM does correctly by default** | Only include if the project convention differs from standard practice |
+
+## Structure Template
+
+```markdown
+---
+description: [Stack] + [domain] conventions
+paths:
+  - "path/**"
+---
+
+# [Domain] Rules
+
+## Architecture
+[Layer boundaries, dependency direction, patterns that vary per project]
+
+## [Domain-Specific Best Practices]
+[Production patterns — forward-looking, not just current state]
+
+## [Key Technical Area]
+[Only non-obvious gotchas and project-specific constraints]
+
+## Testing
+[Only what differs from standard test framework behavior]
+```
+
+Each section: 5-15 lines of bullet points. Prefer prose rules over tables and code blocks — tables document what exists, prose rules guide what should be.
+
+## Research Before Writing
+
+Before writing or rewriting a rules file:
+
+1. **Read the PRD** — understand what system you're building and its production concerns
+2. **Research best practices** for the specific domain (not generic tutorials — production patterns for systems like this one)
+3. **Read adjacent rules files** (`code-quality.md`, `tdd.md`, `workflow.md`) to know what's already covered
+4. **Apply the litmus test** to every line before finalizing


### PR DESCRIPTION
## Summary

Rewrites `.claude/rules/backend.md` from a 105-line codebase documentation file into a 78-line production-focused rules file. Every rule passes the litmus test: would the AI get this wrong without it? Shifts from documenting current patterns to guiding toward best practices (structlog, base exception hierarchy, explicit timeouts, Protocol-based typing). Also adds `docs/RULES-GUIDE.md` documenting how to write effective rules files for downstream stories (#134, #135, #136).

## Test Plan

- [ ] Verify `.claude/rules/backend.md` has correct `paths: ["backend/**"]` frontmatter and loads when editing backend files
- [ ] Confirm no LangGraph/agent-specific rules are present (those belong in `agents.md`, story #134)
- [ ] Confirm no duplication with `code-quality.md` (security, cleanup, dependencies, performance) or `tdd.md` (test cycle, protection rules, coverage)
- [ ] Verify every referenced pattern exists in the codebase: singleton getters (`core/redis.py`, `search/service.py`), domain exceptions (`auth/token_storage.py`), SSE streaming (`agents/router.py`), per-user locks (`auth/google_credentials.py`)
- [ ] Check that best-practice rules are forward-looking (structlog, AppError base class, Redis production config, Protocol for untyped libs) — these guide new code, not just document existing patterns
- [ ] Verify `docs/RULES-GUIDE.md` provides clear guidance for writing rules files in stories #134 (agents.md), #135 (frontend.md), #136 (universal audit)
- [ ] Run `cd backend && uv run pytest` — all 375 tests should pass (no application code changed)
- [ ] Confirm file is token-lean: ~78 lines, ~5.8 KB — within the 60-80 line target for path-scoped rules

---

Closes #133