### PR TITLE
feat(#135): frontend-rules-overhaul

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,131 +1,75 @@
 ---
-description: Next.js 16 + TypeScript + Tailwind + shadcn/ui conventions
+description: Next.js 16 · React 19 · Tailwind v4 · shadcn/ui (Base UI) conventions
 paths:
   - "frontend/**"
 ---
 
-# Frontend Rules (Next.js 16)
+# Frontend Rules
 
-## Server vs Client Components
+## Architecture
 
-- Default to Server Components — only add `"use client"` when you need state, event handlers, effects, or browser APIs
-- Push `"use client"` boundaries DOWN to the smallest interactive leaf component
-- Never put `"use client"` on layouts or pages unless absolutely necessary
-- Use the `children` prop pattern to nest Server Components inside Client Components
-- Import `server-only` in files that must never run on the client
-
-## Data Fetching
-
-- Fetch data in Server Components with async/await — this is the primary pattern
-- Server Actions are for MUTATIONS only — never use them for data fetching
-- Always validate Server Action inputs with Zod
-- Return errors as data from Server Actions, never throw
-- Use `useActionState` for form state management
-- Use Route Handlers for webhooks, external APIs, or when you need full HTTP control
-
-## Streaming and Suspense
-
-- Wrap slow data-fetching components in `<Suspense>` with skeleton fallbacks
-- Never block the shell with top-level awaits in layouts
-- Use `loading.tsx` for route-level loading states
-- Keep layouts structural — no slow data fetching in layouts
-
-## Error Handling
-
-- Use `error.tsx` (must be `"use client"`) for error boundaries at each route level
-- Use `not-found.tsx` with `notFound()` for 404 states
+- Default to Server Components — add `"use client"` only for state, event handlers, effects, or browser APIs
+- Push `"use client"` DOWN to the smallest interactive leaf; use the `children` prop pattern to nest Server Components inside Client wrappers
+- Import `server-only` in modules that must never run on the client (`lib/api.ts`, auth utilities)
+- `proxy.ts` is the traffic cop — redirects, rewrites, auth checks, header modification only. Never fetch data, manage sessions, or aggregate in proxy
+- `error.tsx` (must be `"use client"`) for route-level error boundaries; `not-found.tsx` with `notFound()` for 404 states
 - Handle event handler errors with try/catch + useState, not error boundaries
+- Use `use cache` for explicit caching (replaces implicit ISR) — pair with `cacheLife()` and `cacheTag()` for granular control
+- Every parallel route slot requires an explicit `default.js` — builds fail silently without it
 
-## proxy.ts (replaces middleware.ts)
+## Data Fetching & Mutations
 
-- Keep it lean — traffic cop, not database admin
-- Use for: redirects, rewrites, auth checks, header modification
-- Never use for: heavy data fetching, session management, data aggregation
+- Fetch in Server Components with async/await — the primary read pattern
+- Server Actions for MUTATIONS only — never for data fetching
+- Validate all Server Action inputs with Zod; return errors as data (`{ success, error? }`), never throw
+- Route Handlers for webhooks, external APIs, or when you need full HTTP control (e.g., SSE proxy at `/api/chat`)
+- `useActionState` for form state management — this replaced the deprecated `useFormState` in React 19
+- `useOptimistic` for instant UI feedback before server confirmation (likes, adds, toggles)
+- `<form action={serverAction}>` for progressive enhancement — use `redirect()` inside the action for no-JS fallback
 
-## TypeScript
+## React 19 Patterns
 
-- `strict: true` always — never disable
-- Never use `any` — use `unknown` and narrow with type guards
-- Never use `@ts-ignore` — fix the actual type issue
-- Use `interface` for component props (more extensible than `type`)
-- Use discriminated unions for mutually exclusive state, not boolean flags
-- Use `z.infer<typeof schema>` to derive types from Zod schemas — single source of truth
-- `noUncheckedIndexedAccess: true` — always check index access results for `undefined`
-- Never add `@ts-expect-error` without an explanatory comment describing why
+- `ref` is a regular prop — never use `forwardRef` (deprecated in React 19). Write `function MyButton({ ref, ...props })` directly
+- `use()` hook reads promises passed from Server to Client Components — do NOT create promises client-side and pass them to `use()`. In Server Components, prefer plain `async/await`
+- React Compiler is stable — never manually add `useMemo`, `useCallback`, or `React.memo`. The compiler handles memoization automatically. Remove manual memoization when touching existing code
+- Use discriminated unions for mutually exclusive state (`type State = { status: 'loading' } | { status: 'error'; error: string } | { status: 'success'; data: T }`), not boolean flags
 
-## Documentation
+## Tailwind v4 + shadcn/ui
 
-- Add `/** ... */` JSDoc to exported utility functions in `lib/` and custom hooks in `hooks/`
-- Do NOT add JSDoc to React components — the component name + props interface are the documentation
-- Do NOT add JSDoc to props interfaces — property names + TypeScript types are self-documenting
-- Server Actions and Route Handlers: add a one-line JSDoc describing what the action/handler does (these are effectively API endpoints)
-- Inline comments: explain "why" not "what" — non-obvious Tailwind workarounds, browser-specific hacks, Next.js caching behavior
-
-## Tailwind + shadcn/ui
-
-- Never use inline styles — always Tailwind classes
-- Always use `cn()` from shadcn for conditional classNames — never concatenate strings
-- Mobile-first: unprefixed utilities are the mobile styles, use `md:`, `lg:` for larger screens
-- Never use arbitrary values (`mt-[13px]`) — use theme values
-- Extract repeated patterns into React components, not `@apply` classes
-- ALWAYS use the `shadcn` skill when adding new UI primitives — never copy-paste or manually create shadcn components
-
-## Skills — MUST invoke before building UI
-
-These skills provide design intelligence that Claude does not have natively. Without them, UI output defaults to safe, generic choices — correct but bland. The skills exist to push past that.
-
-**A plan that prescribes specific UI values (colors, spacing, Tailwind classes) does NOT substitute for skill invocation.** The plan captures *what to change*; the skill provides *design intelligence* about *how to make it look good*. Even if a plan is highly prescriptive, invoke the relevant skill before the first edit to validate and improve the plan's visual choices.
-
-### Skills and why they matter
-
-| Skill | Invoke BEFORE... | Why — what goes wrong without it |
-|-------|------------------|----------------------------------|
-| **`frontend-design`** | Writing or modifying ANY visual component, page, or layout. Before choosing colors, spacing, typography, or visual hierarchy. | Without it: you pick safe defaults (gray tokens, uniform spacing, no visual rhythm). The skill provides opinionated, anti-generic-AI design direction — distinctive layouts, spatial hierarchy, and polish that make interfaces feel designed rather than assembled. |
-| **`shadcn`** | Adding, composing, or debugging ANY shadcn/ui component. Before manually creating files in `components/ui/`. | Without it: you might manually create a component that shadcn already provides, or miss composition patterns (compound components, slot APIs) that the library supports. |
-| **`vercel-react-best-practices`** | Touching data fetching, bundle-affecting imports, image loading, or rendering strategy. When adding `"use client"`. | Without it: you may create unnecessary client boundaries, miss streaming opportunities, or introduce bundle bloat that degrades performance. |
-| **`vercel-composition-patterns`** | Building compound components, extracting shared APIs, or when a component exceeds ~80 lines. | Without it: components grow monolithic with boolean prop proliferation instead of clean composition patterns. |
-
-### Enforcement: before first edit, not before PR
-
-Skill invocation is a **pre-implementation** step, not a post-implementation gate. The workflow is:
-
-1. **Before the first edit** to any visual file: invoke `frontend-design` to get opinionated design direction and specific aesthetic recommendations
-2. **Before creating/editing** any `components/ui/` file: invoke `shadcn` to check if the component exists or has a preferred composition pattern
-3. **After edits**: run the Visual Self-Review Loop (see below)
-
-If you already wrote the code without invoking a skill: stop, invoke the skill, and be willing to revise. Sunk cost is not a reason to skip design review.
-
-### Visual Self-Review Loop (MANDATORY after every visual change)
-
-jsdom tests verify behavior but not appearance. **Screenshots are the only source of truth.**
-
-After every batch of visual changes, run `pnpm e2e:screenshots`, then Read and inspect every affected screenshot. For each one, **write out specific findings** — "looks good" is not acceptable. Check for:
-
-- **Overflow & clipping**: text cut off, content bleeding, scroll bars where they shouldn't be, sidebar bottom truncated
-- **Data visibility**: overlapping calendar events (need collision layout), obscured labels, missing profile images/avatars
-- **Interaction cues**: buttons need clear affordance, async actions need loading/spinner states, inputs need visible focus rings
-- **Polish**: clear type hierarchy, consistent spacing, UI should look like a finished product (think Google Calendar / Linear) not a template
-
-If anything fails: fix it, re-screenshot, re-inspect. **Do not move on while screenshot issues remain.** This fix-and-reshoot cycle is how UI quality actually improves.
+- CSS-first configuration — all theme tokens live in `globals.css` via `@theme inline`. Never create a `tailwind.config.js`
+- OKLCH color space for all colors — follow `frontend/DESIGN.md` tokens. Never use hex or rgb values
+- Always use `cn()` for conditional classNames — never concatenate strings
+- Mobile-first: unprefixed utilities are the mobile base, `md:`/`lg:` for larger screens
+- No arbitrary values (`mt-[13px]`) — use theme tokens. If a token doesn't exist, add it to `@theme`
+- Extract repeated class patterns into React components, not `@apply`
+- Use `shadcn` skill when adding UI primitives — never manually create files in `components/ui/`
+- This project uses `@base-ui/react` (not Radix) — use render props for composition, not `asChild`
+- Container queries (`@container`) are built-in — no plugin needed
+- Tailwind v4 changed defaults: border/ring color = `currentColor`, ring width = `1px`. Test visuals after any component migration
 
 ## Component Patterns
 
-- Components should do ONE thing — extract sub-components at ~50-80 lines
-- Never declare components inside other components — extract to separate functions/files
-- Use semantic HTML (`<main>`, `<section>`, `<nav>`, `<header>`) not div soup
-- Every interactive element must be keyboard-accessible with proper ARIA attributes
-- Always use `next/image` (not `<img>`) and `next/font` (not external font links)
-- Always set `width`/`height` or `fill` on images to prevent layout shifts
+- One responsibility per component — extract sub-components at ~50-80 lines
+- Never declare components inside other components — extract to separate functions or files
+- Semantic HTML (`<main>`, `<section>`, `<nav>`, `<header>`) over div soup
+- `next/image` with `width`/`height` or `fill` — never use bare `<img>` tags
+- Every interactive element: keyboard-accessible with proper ARIA attributes
 
-## Forms (React Hook Form + Zod)
+## Skills
 
-- Define validation schema with Zod first
-- Use `useForm<z.infer<typeof schema>>({ resolver: zodResolver(schema) })`
-- Make error messages actionable: "Username must be at least 3 characters" not "Invalid input"
+Invoke BEFORE the first edit, not after. If code was already written without a skill: stop, invoke, revise.
 
-## Testing
+1. `impeccable:frontend-design` — before ANY visual work (components, pages, layouts). Provides opinionated design direction. Style guide: `frontend/DESIGN.md`
+2. `shadcn` — before adding or editing `components/ui/` files. Checks if the component exists and provides composition patterns
+3. `vercel-react-best-practices` — before touching data fetching, bundle-affecting imports, or rendering strategy
+4. `vercel-composition-patterns` — when a component exceeds ~80 lines or needs compound component patterns
 
-- Use Vitest + Testing Library for component tests
-- Prefer `getByRole` over `getByTestId` — matches user experience
-- Test user-visible behavior, not implementation details
-- Every component with data fetching must test loading AND error states
+## Visual Self-Review Loop
+
+jsdom tests verify behavior, not appearance. Screenshots are the only source of truth.
+
+After every batch of visual changes:
+1. Run `pnpm e2e:screenshots`
+2. Read every affected screenshot — write specific findings ("looks good" is not acceptable)
+3. Check: overflow/clipping, data visibility, interaction cues, type hierarchy, consistent spacing
+4. Fix issues → re-screenshot → re-inspect. Do not move on while screenshot issues remain

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -37,7 +37,7 @@ paths:
 ## Tailwind v4 + shadcn/ui
 
 - CSS-first configuration — all theme tokens live in `globals.css` via `@theme inline`. Never create a `tailwind.config.js`
-- OKLCH color space for all colors — follow `frontend/DESIGN.md` tokens. Never use hex or rgb values
+- OKLCH color space for all colors — follow `.impeccable.md` design tokens. Never use hex or rgb values
 - Always use `cn()` for conditional classNames — never concatenate strings
 - Mobile-first: unprefixed utilities are the mobile base, `md:`/`lg:` for larger screens
 - No arbitrary values (`mt-[13px]`) — use theme tokens. If a token doesn't exist, add it to `@theme`
@@ -59,7 +59,7 @@ paths:
 
 Invoke BEFORE the first edit, not after. If code was already written without a skill: stop, invoke, revise.
 
-1. `impeccable:frontend-design` — before ANY visual work (components, pages, layouts). Provides opinionated design direction. Style guide: `frontend/DESIGN.md`
+1. `impeccable:frontend-design` — before ANY visual work (components, pages, layouts). Provides opinionated design direction. Style guide: `.impeccable.md`
 2. `shadcn` — before adding or editing `components/ui/` files. Checks if the component exists and provides composition patterns
 3. `vercel-react-best-practices` — before touching data fetching, bundle-affecting imports, or rendering strategy
 4. `vercel-composition-patterns` — when a component exceeds ~80 lines or needs compound component patterns


### PR DESCRIPTION
## Summary

Rewrites `.claude/rules/frontend.md` applying RULES-GUIDE litmus-test discipline — trimming generic patterns the AI already knows, removing overlap with `code-quality.md` and `tdd.md`, and incorporating forward-looking Next.js 16 / React 19 / Tailwind v4 / Base UI best practices from targeted research. Reduces 132 lines to 75 (43% reduction) while adding new rules the AI would get wrong without guidance.

## Test Plan

- [ ] **Litmus test compliance**: Read every line in the rewritten `frontend.md` and verify: (1) AI would get it wrong without the rule, (2) not discoverable by reading one file, (3) not already in another rules file
- [ ] **No overlap**: Grep `frontend.md` for terms from `code-quality.md` (JSDoc, docstring, console.log) and `tdd.md` (Vitest, Testing Library, getByRole) — should find no matches
- [ ] **Skills section**: Confirm `impeccable:frontend-design` is listed first with pointer to `frontend/DESIGN.md`, followed by `shadcn`, `vercel-react-best-practices`, `vercel-composition-patterns`
- [ ] **Visual Self-Review Loop**: Confirm screenshot → inspect → fix → reshoot cycle is retained
- [ ] **Research-backed rules**: Verify presence of: `forwardRef` deprecation, `useActionState` rename, React Compiler guidance, `use cache` directive, `@theme inline`, OKLCH, Base UI render props, container queries
- [ ] **Frontmatter**: Confirm `paths: ["frontend/**"]` is correct
- [ ] **Line count**: Verify file is within 60-130 line range (75 lines)
- [ ] **No regressions**: `pnpm typecheck` and `pnpm lint` pass clean

---

Closes #135